### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ opam install core ounit react
 
 ## Running Tests
 
-To run all the tests, type `make` from the top level xocaml directory.
+To run all the tests, type `make` from the top level ocaml directory.
 
 To run tests for an individual exercise, `make test-assignment ASSIGNMENT=luhn`
 
@@ -60,7 +60,7 @@ is documentation [here](tools/test-generator/README.md).
 
 ## Feedback
 
-If you find this documentation is inaccurate or incomplete, or can be improved in any way, please don't hesitate to raise an [issue](https://github.com/exercism/xocaml/issues) or submit a pull request.
+If you find this documentation is inaccurate or incomplete, or can be improved in any way, please don't hesitate to raise an [issue](https://github.com/exercism/ocaml/issues) or submit a pull request.
 
 
 ### OCaml icon

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "ocaml",
   "language": "OCaml",
-  "repository": "https://github.com/exercism/xocaml",
+  "repository": "https://github.com/exercism/ocaml",
   "active": true,
   "exercises": [
     {

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -23,7 +23,7 @@ opam install utop
 Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/xocaml](https://github.com/exercism/xocaml) repository on
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
 GitHub is the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new

--- a/tools/test-generator/README.md
+++ b/tools/test-generator/README.md
@@ -17,9 +17,9 @@ This will build and run the unit tests
 The test generator should be run whenever test canonical data is updated.
 
 You will need the latest version of x-common checked out locally, at the same level as your
-xocaml repo. 
+ocaml repo. 
 
-Please note: running will overwrite tests in the xocaml/exercises folders (this is the default, there
+Please note: running will overwrite tests in the ocaml/exercises folders (this is the default, there
 is a command line option to write the tests to a different folder - run test_gen.native --help).
 
 To run, type test_gen.native at the command line.


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1