### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 script:
   - bash -ex .travis-ci.sh
   - bin/fetch-configlet
-  - bin/configlet .
+  - bin/configlet lint .
 
 env:
   - OCAML_VERSION=4.04.1 OPAM_VERSION=1.2.2


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23