### PR TITLE
Hamming exercise: fix "Unbound module Sexp" error

### DIFF
--- a/exercises/hamming/test.ml
+++ b/exercises/hamming/test.ml
@@ -1,6 +1,7 @@
 (* Test/exercise version: "2.0.1" *)
 
 open Core
+open Core.Std
 open OUnit2
 
 let printer n =


### PR DESCRIPTION
When I run `make` for the Hamming exercise, I get the following compilation error:

```
+ ocamlfind ocamlc -c -w A-4-33-40-41-42-43-34-44 -strict-sequence -g -bin-annot -short-paths -thread -package oUnit -package core -ppx 'ppx-jane -as-ppx' -o test.cmo test.ml
File "test.ml", line 8, characters 5-19:
Error: Unbound module Sexp
Command exited with code 2.
Makefile:5: recipe for target 'test.native' failed
make: *** [test.native] Error 10
```

Adding `open Core.Std` makes the Sexp module available.