### PR TITLE
Improve installation docs

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,5 +1,36 @@
-Follow the [installation instructions](https://github.com/realworldocaml/book/wiki/Installation-Instructions) of the excellent [Real World OCaml](https://realworldocaml.org/) book. Afterwards be sure to install [OUnit](http://ounit.forge.ocamlcore.org/) using
+1. Install the OCaml compiler (`ocaml`) and package manager (`opam`).
 
-```bash
-opam install ounit
-```
+   The excellent [Real World OCaml](https://realworldocaml.org/) book has
+   [installation
+   instructions](https://github.com/realworldocaml/book/wiki/Installation-Instructions)
+   for a variety of operating systems.
+
+2. If you followed the instructions from Real World OCaml, it is likely that
+   your system's OCaml compiler is not the latest version.
+
+   To see a list of available versions and the one you have currently installed,
+   run:
+
+   ```bash
+   opam switch
+   ```
+
+   Note which version is the latest and install it by running:
+
+   ```bash
+   opam switch <version-number>
+   ```
+
+   For example, if the latest version is 4.06.0, you will run:
+
+   ```bash
+   opam switch 4.06.0
+   ```
+
+3. Install the Core and [OUnit](http://ounit.forge.ocamlcore.org/) packages,
+   which are necessary in order to run the exercise tests:
+
+   ```bash
+   opam install core ounit
+   ```
+


### PR DESCRIPTION
These instructions include switching to the latest release version of the OCaml compiler, something I found myself needing to do (see #234).

An open question is whether we should specify a minimum compiler version in order to run the exercise tests, or if it's sufficient to recommend installing the latest release version (like I have it in this PR).