### PR TITLE
Base.string_of_bool <- Bool.to_string

### DIFF
--- a/exercises/leap/test.ml
+++ b/exercises/leap/test.ml
@@ -3,7 +3,7 @@
 open OUnit2
 open Leap
 
-let ae exp got _test_ctxt = assert_equal exp got ~printer:string_of_bool
+let ae exp got _test_ctxt = assert_equal exp got ~printer:Bool.to_string
 
 let tests = [
   "year not divisible by 4: common year" >::


### PR DESCRIPTION
Base.string_of_bool is deprecated since 2016-09 and produce a warning.