### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -51,7 +51,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -121,7 +121,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "arithmetic",
         "floats"
       ]
     },
@@ -131,9 +130,7 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": [
-        "mathematics"
-      ]
+      "topics": []
     },
     {
       "slug": "pangram",
@@ -162,7 +159,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -181,9 +178,7 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": [
-        "arithmetic"
-      ]
+      "topics": []
     },
     {
       "slug": "binary-search",
@@ -257,7 +252,7 @@
       "difficulty": 5,
       "topics": [
         "algorithms",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -277,7 +272,7 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-        "arithmetic"
+        "math"
       ]
     },
     {


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110