### PR TITLE
Improve acronym test cases

### DIFF
--- a/exercises/acronym/test.ml
+++ b/exercises/acronym/test.ml
@@ -15,6 +15,8 @@ let tests = [
     ae "GIMP" (acronym "GNU Image Manipulation Program");
   "punctuation without whitespace" >::
     ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+    ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
 ]
 
 let () =

--- a/exercises/acronym/test.ml
+++ b/exercises/acronym/test.ml
@@ -17,6 +17,8 @@ let tests = [
     ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
   "very long abbreviation" >::
     ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+    ae "SIMUFTA" (acronym "Something - I made up from thin air");
 ]
 
 let () =


### PR DESCRIPTION
* Add  missing `very long abbreviation` test case from [exercism/problem-specifications](https://github.com/exercism/problem-specifications/blob/ca7994385d78154e91e85c88ae2d28ef11850ad0/exercises/acronym/canonical-data.json#L48-L55)

* Add new test case `consecutive delimiters` that catch unsafe implementations lacking a check for strings of length `0`, e.g.:

   ```ml
   open Core_kernel

   let acronym input =
      String.split_on_chars ~on:[' '; '-'] input 
      (* fails for new test case with out of bounds *)
      |> List.map ~f:(fun word -> String.nget word 0) 
      |> (* omitted *);;
   ```

   Relevant spec PR: https://github.com/exercism/problem-specifications/pull/1321