### PR TITLE
Migrate exercises to Base

### DIFF
--- a/exercises/nucleotide-count/dune
+++ b/exercises/nucleotide-count/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries base oUnit core_kernel))
+ (libraries base oUnit))
 
 (alias
   (name    runtest)

--- a/exercises/nucleotide-count/example.ml
+++ b/exercises/nucleotide-count/example.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Base
 open Base.Continue_or_stop
 
 let is_nucleotide = function
@@ -14,11 +14,11 @@ let count_nucleotide s c =
                         Continue (if Char.equal c c' then n+1 else n))
 
 let count_nucleotides =
-  let incr = Char.Map.change ~f:(function
+  let incr = Map.change ~f:(function
                  | None -> Some 1
                  | Some n -> Some (n + 1))
   in String.fold_until
-       ~init:Char.Map.empty
+       ~init:(Map.empty (module Char))
        ~finish:Result.return
        ~f:(fun acgt c -> if is_nucleotide c
                          then Continue (incr acgt c)

--- a/exercises/nucleotide-count/nucleotide_count.mli
+++ b/exercises/nucleotide-count/nucleotide_count.mli
@@ -1,7 +1,7 @@
-open Core_kernel
+open Base
 
 (* Count the number of times a nucleotide occurs in the string. *)
 val count_nucleotide : string -> char -> (int, char) Result.t
 
 (* Count the nucleotides in the string. *)
-val count_nucleotides : string -> (int Char.Map.t, char) Result.t
+val count_nucleotides : string -> (int Map.M(Char).t, char) Result.t

--- a/exercises/nucleotide-count/test.ml
+++ b/exercises/nucleotide-count/test.ml
@@ -1,7 +1,6 @@
-open Core_kernel
+open Base
 open OUnit2
 
-module CharMap = Char.Map
 module NC = Nucleotide_count
 
 (* Assert that two 'int option' values are equivalent. *)
@@ -16,12 +15,13 @@ let aire exp got _ctxt =
 
 (* Assert that two '(int Char.Map.t, char) Result.t' values are equivalent. *)
 let amre exp got _ctxt =
+  let sexp_of_map = Map.sexp_of_m__t (module Char) in
   let printer m =
-    Result.sexp_of_t (CharMap.sexp_of_t Int.sexp_of_t) Char.sexp_of_t m
+    Result.sexp_of_t (sexp_of_map Int.sexp_of_t) Char.sexp_of_t m
     |> Sexp.to_string_hum ~indent:1
   in
   let cmp exp got = match exp, got with
-    | Ok exp_map, Ok got_map -> CharMap.equal Int.equal exp_map got_map
+    | Ok exp_map, Ok got_map -> Map.equal Int.equal exp_map got_map
     | Error c1, Error c2     -> Char.equal c1 c2
     | _ -> false
   in assert_equal exp got ~cmp ~printer
@@ -41,20 +41,20 @@ let tests =
       amre (Error 'X') (NC.count_nucleotides "ACGXT");
 
     "Empty DNA string has zero nucleotides" >::
-      amre (Ok CharMap.empty) (NC.count_nucleotides "");
+      amre (Ok (Map.empty (module Char))) (NC.count_nucleotides "");
 
     "DNA string with two Adenine nucleotides" >::
-      amre (Ok (CharMap.singleton 'A' 2)) (NC.count_nucleotides "AA");
+      amre (Ok (Map.singleton (module Char) 'A' 2)) (NC.count_nucleotides "AA");
 
     "DNA string with one Adenine, two Cytosine nucleotides" >::
       begin
-        let exp = Ok (CharMap.of_alist_exn [('A', 1); ('C', 2)])
+        let exp = Ok ((Map.of_alist_exn (module Char)) [('A', 1); ('C', 2)])
         in amre exp (NC.count_nucleotides "ACC")
       end;
 
     "DNA string with one Adenine, two Cytosine, three Guanine, four Thymine nucleotides" >::
       begin
-        let exp = Ok (CharMap.of_alist_exn [('A', 1); ('C', 2); ('G', 3); ('T', 4)])
+        let exp = Ok ((Map.of_alist_exn (module Char)) [('A', 1); ('C', 2); ('G', 3); ('T', 4)])
         in amre exp (NC.count_nucleotides "CGTATGTCTG")
       end;
   ]

--- a/exercises/react/dune
+++ b/exercises/react/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries core_kernel oUnit))
+ (libraries base oUnit))
 
 (alias
   (name    runtest)

--- a/exercises/react/test.ml
+++ b/exercises/react/test.ml
@@ -1,12 +1,13 @@
-open Core_kernel
+open Base
 open OUnit2
 open React
 
 let ae exp got =
-  assert_equal ~printer:(Int.to_string) exp got;;
+  assert_equal exp got ~printer:Int.to_string
 
 let assert_list_eq exp got =
-  assert_equal ~printer:(List.to_string ~f:Int.to_string) exp got;;
+  let printer xs = List.sexp_of_t Int.sexp_of_t xs |> Sexp.to_string_hum ~indent:1 in
+  assert_equal exp got ~printer
 
 let create_int_input_cell = create_input_cell ~eq:Int.equal
 let create_compute_cell_1 = create_compute_cell_1 ~eq:Int.equal
@@ -24,7 +25,7 @@ let tests = [
   );
   "compute cells calculate from an initial value" >:: (fun _ctx ->
     let cell = create_int_input_cell ~value:1 in
-    let computed = create_compute_cell_1 cell ~f:succ in
+    let computed = create_compute_cell_1 cell ~f:Int.succ in
     ae 2 (value_of computed)
   );
   "compute cells take inputs in the right order" >:: (fun _ctx ->
@@ -35,7 +36,7 @@ let tests = [
   );
   "compute cells update value when dependencies are changed" >:: (fun _ctx ->
     let input = create_int_input_cell ~value:1 in
-    let computed = create_compute_cell_1 input ~f:succ in
+    let computed = create_compute_cell_1 input ~f:Int.succ in
     set_value input 3;
     ae 4 (value_of computed)
   );
@@ -51,7 +52,7 @@ let tests = [
   );
   "compute cells fire callbacks" >:: (fun _ctx ->
     let input = create_int_input_cell ~value:1 in
-    let output = create_compute_cell_1 input ~f:succ in
+    let output = create_compute_cell_1 input ~f:Int.succ in
     let record = ref [] in
     ignore @@ add_callback output ~k:(fun x -> record := x :: !record);
     
@@ -109,7 +110,7 @@ let tests = [
   );
   "removing a callback multiple times doesn't interfere with other callbacks" >:: (fun _ctx ->
     let input = create_int_input_cell ~value:1 in
-    let output = create_compute_cell_1 input ~f:succ in
+    let output = create_compute_cell_1 input ~f:Int.succ in
     let callback1_calls = ref [] in
     let callback2_calls = ref [] in
     let cb1 = add_callback output ~k:(fun x -> callback1_calls := x :: !callback1_calls) in
@@ -124,9 +125,9 @@ let tests = [
   );
   "callbacks should only be called once even if multiple dependencies change" >:: (fun _ctx ->
     let input = create_int_input_cell ~value:1 in
-    let plus_one = create_compute_cell_1 input ~f:succ in
-    let minus_one1 = create_compute_cell_1 input ~f:pred in
-    let minus_one2 = create_compute_cell_1 minus_one1 ~f:pred in
+    let plus_one = create_compute_cell_1 input ~f:Int.succ in
+    let minus_one1 = create_compute_cell_1 input ~f:Int.pred in
+    let minus_one2 = create_compute_cell_1 minus_one1 ~f:Int.pred in
     let output = create_compute_cell_2 plus_one minus_one2 ~f:((fun x y -> x * y)) in
     
     let callback1_calls = ref [] in
@@ -137,8 +138,8 @@ let tests = [
   );
   "callbacks should not be called if dependencies change but output value doesn't change" >:: (fun _ctx ->
     let input = create_int_input_cell ~value:1 in
-    let plus_one = create_compute_cell_1 input ~f:succ in
-    let minus_one1 = create_compute_cell_1 input ~f:pred in
+    let plus_one = create_compute_cell_1 input ~f:Int.succ in
+    let minus_one1 = create_compute_cell_1 input ~f:Int.pred in
     let always_two = create_compute_cell_2 plus_one minus_one1 ~f:(fun x y -> x - y) in
     
     let callback1_calls = ref [] in

--- a/exercises/word-count/dune
+++ b/exercises/word-count/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries core_kernel oUnit))
+ (libraries base oUnit))
 
 (alias
   (name    runtest)

--- a/exercises/word-count/example.ml
+++ b/exercises/word-count/example.ml
@@ -1,12 +1,10 @@
-open Core_kernel
-
-module SMap = String.Map
+open Base
 
 let add_to_map wcs w =
-  SMap.update wcs w ~f:(fun k -> Option.value_map k ~default:1 ~f:((+) 1))
+  Map.update wcs w ~f:(fun k -> Option.value_map k ~default:1 ~f:((+) 1))
 
 let normalize = function
-  | ch when Char.is_alphanum ch || ch = '\'' -> Char.lowercase ch
+  | ch when Char.is_alphanum ch || Char.equal ch '\'' -> Char.lowercase ch
   | _ -> ' '
 
 let word_count s =
@@ -14,4 +12,4 @@ let word_count s =
   let s = String.substr_replace_all s ~pattern:"\' " ~with_:" " in
   let s = String.map s ~f:normalize in
   let split = List.filter (String.split s ~on:' ') ~f:(Fn.non String.is_empty) in
-  List.fold ~init:SMap.empty ~f:add_to_map split
+  List.fold ~init:(Map.empty (module String)) ~f:add_to_map split

--- a/exercises/word-count/test.ml
+++ b/exercises/word-count/test.ml
@@ -1,12 +1,12 @@
-open Core_kernel
+open Base
 open OUnit2
 open Word_count
 
-module SMap = String.Map
-
 let ae exp got _test_ctxt =
-  let printer m = SMap.sexp_of_t Int.sexp_of_t m |> Sexp.to_string_hum ~indent:1 in
-  assert_equal (SMap.of_alist_exn exp) got ~cmp:(SMap.equal (=)) ~printer
+  let cmp = Map.equal (=) in
+  let sexp_of_map = Map.sexp_of_m__t (module String) in
+  let printer m = sexp_of_map Int.sexp_of_t m |> Sexp.to_string_hum ~indent:1 in
+  assert_equal ((Map.of_alist_exn (module String)) exp) got ~cmp ~printer
 
 let tests = [
    "count one word" >::

--- a/exercises/word-count/word_count.mli
+++ b/exercises/word-count/word_count.mli
@@ -1,4 +1,4 @@
-open Core_kernel
+open Base
 
 (**
  * Count occurences of words (consisting of letters and numbers) in the string.
@@ -6,4 +6,4 @@ open Core_kernel
  * Words will be converted to lower case before comparison and insertion in the
  * map.
  *)
-val word_count : string -> int String.Map.t
+val word_count : string -> int Map.M(String).t

--- a/exercises/zipper/dune
+++ b/exercises/zipper/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries core_kernel oUnit)
+ (libraries base oUnit)
  (preprocess (pps ppx_sexp_conv)))
 
 (alias

--- a/exercises/zipper/example.ml
+++ b/exercises/zipper/example.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Base
 
 type 'a trail =
   | L of 'a * 'a Tree.t option * 'a trail (* Left path taken *)

--- a/exercises/zipper/test.ml
+++ b/exercises/zipper/test.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Base
 open OUnit2
 
 module T = Tree

--- a/exercises/zipper/tree.ml
+++ b/exercises/zipper/tree.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Base
 
 type 'a t = { value : 'a; left : 'a t option; right : 'a t option }
   [@@deriving sexp]

--- a/exercises/zipper/tree.mli
+++ b/exercises/zipper/tree.mli
@@ -1,4 +1,4 @@
-open Core_kernel
+open Base
 
 type 'a t = { value : 'a; left : 'a t option; right : 'a t option }
 

--- a/exercises/zipper/zipper.mli
+++ b/exercises/zipper/zipper.mli
@@ -1,5 +1,5 @@
 (** Zipper exercise interface *)
-open Core_kernel
+open Base
 
 (** The type of a zipper *)
 type 'a t


### PR DESCRIPTION
I only lack `meetup`, but I don't know what Base has to offer in terms of Date packages.

Perhaps this exercise isn't a candidate and should remain as Core_kernel.

See #277.