### PR TITLE
Change READMEs to use Base

### DIFF
--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -12,10 +12,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -36,10 +36,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -34,10 +34,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `QCheck`. Install it using `opam`:

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -11,10 +11,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -52,10 +52,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -325,10 +325,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -39,10 +39,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -47,10 +47,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -65,10 +65,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -8,10 +8,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -21,10 +21,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -35,10 +35,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -12,10 +12,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -17,10 +17,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -19,10 +19,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -51,10 +51,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -30,10 +30,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -27,10 +27,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -40,10 +40,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/hangman/README.md
+++ b/exercises/hangman/README.md
@@ -22,10 +22,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -19,10 +19,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -12,10 +12,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -31,10 +31,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -11,10 +11,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -69,10 +69,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -31,10 +31,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -31,10 +31,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -36,10 +36,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -41,10 +41,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -13,10 +13,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -33,10 +33,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -34,10 +34,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -22,10 +22,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -20,10 +20,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -68,10 +68,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -23,10 +23,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -20,10 +20,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -47,10 +47,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -28,10 +28,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -67,10 +67,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -22,10 +22,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -27,10 +27,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -16,10 +16,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -32,10 +32,10 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/ocaml).
 
 ## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
 
 ```bash
-opam install core
+opam install base
 ```
 
 To run the tests you will need `OUnit`. Install it using `opam`:


### PR DESCRIPTION
Hi !

I changed all core installation paragraph in exercises' README.md to base as asked in [this issue](https://github.com/exercism/ocaml/issues/288).

However, I skipped customize paragraph for exercises `hangman`, `allergies` and `meetup`.