### PR TITLE
Add nucleotide_count.ml stub file for handout

### DIFF
--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -25,7 +25,7 @@ The exercise consists of two parts:
   nucleotide occurs in the string.  If the nucleotide `c` is invalid, or the
   DNA string contains an invalid nucleotide `c`, the result should be `Error c`.
 - Given an input DNA string, count all the nucleotides in the string and
-  gather the result in a `Char.Map`.  If the DNA string contains an invalid
+  gather the result in a `Map`.  If the DNA string contains an invalid
   nucleotide `c`, the result should be `Error c`.  Otherwise the result
   should be `Ok map`.
 

--- a/exercises/nucleotide-count/nucleotide_count.ml
+++ b/exercises/nucleotide-count/nucleotide_count.ml
@@ -1,0 +1,9 @@
+open Base
+
+let empty = Map.empty (module Char)
+
+let count_nucleotide s c =
+  failwith "'count_nucleotide' is missing"
+
+let count_nucleotides s =
+  failwith "'count_nucleotides' is missing"


### PR DESCRIPTION
I'd like to see if it's enough to provide a stub and not expand on the explanation in README.

@stevejb71: Does the .ml stub automatically get copied along?