### PR TITLE
Fix anagram unit test for Base v0.12.0

### DIFF
--- a/exercises/anagram/test.ml
+++ b/exercises/anagram/test.ml
@@ -4,7 +4,7 @@ open Anagram
 
 let ae exp got _test_ctxt =
   let printer = String.concat ~sep:";" in
-  assert_equal exp got ~cmp:(List.equal ~equal:String.equal) ~printer
+  assert_equal exp got ~printer
 
 let tests = [
   "no matches" >::


### PR DESCRIPTION
Today I spent way too much time looking for an error in my own code before I realized it actually came from the unit test 🤦‍♂️  

Here's the error:

```
File "test.ml", line 7, characters 47-59:
Error: The function applied to this argument has type
         ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
```

Coming from the following line:

```ocaml
assert_equal exp got ~cmp:(List.equal ~equal:String.equal) ~printer
```

This can be fixed either by using

```ocaml
assert_equal exp got ~cmp:(List.equal String.equal) ~printer
```

or by just leaving off `~cmp:` completely:

```ocaml
assert_equal exp got ~printer
```

Looking at `Base`'s changelog, the following seems to be the culprit:

- Changed the signature of `equal` from `'a t -> 'a t -> equal:('a -> 'a ->
  bool) -> bool` to `('a -> 'a -> bool) -> 'a t -> 'a t -> bool`.