### PR TITLE
Change exercise readme template

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -4,49 +4,33 @@
 {{- with .Hints }}
 {{ . }}
 {{ end }}
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install core
-```
-
-Documentation for Core can be found [here](https://ocaml.janestreet.com/ocaml-core/latest/doc/core/)
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 {{ with .Spec.Credits }}
 ## Source
 
 {{ . }}
 {{ end }}
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,36 +1,48 @@
-1. Install the OCaml compiler (`ocaml`) and package manager (`opam`).
+To work on the exercises, you will need these pieces of software:
 
-   The excellent [Real World OCaml](https://realworldocaml.org/) book has
-   [installation
-   instructions](https://github.com/realworldocaml/book/wiki/Installation-Instructions)
-   for a variety of operating systems.
+1. [`OPAM`, the OCaml Package manager](https://opam.ocaml.org/)
 
-2. If you followed the instructions from Real World OCaml, it is likely that
-   your system's OCaml compiler is not the latest version.
+   See [Real World Ocaml, 2nd Ed.: Installation Instructions](https://dev.realworldocaml.org/install.html)
+   for how to install and configure `OPAM` for your operating system.
 
-   To see a list of available versions and the one you have currently installed,
-   run:
+2. The OCaml compiler
+
+   See a list of available versions:
 
    ```bash
    opam switch
    ```
 
-   Note which version is the latest and install it by running:
+   Switch to that version. If, for example, the latest version is 4.08.0, you will run:
 
    ```bash
-   opam switch <version-number>
+   opam switch 4.08.0
    ```
 
-   For example, if the latest version is 4.07.0, you will run:
+3. Install extended standard libraries and test libraries
+
+   Some exercises use only the OCaml standard library, and some use the
+   extended libraries by Jane Street called Base and Core\_kernel.
+
+   The test library is called OUnit, and some exercises additionally use the
+   QCheck library for property-based tests.
 
    ```bash
-   opam switch 4.07.0
+   opam install base core_kernel ounit qcheck
    ```
 
-3. Install the Core_kernel, [Base](https://ocaml.janestreet.com/ocaml-core/latest/doc/base/Base/index.html) and [OUnit](http://ounit.forge.ocamlcore.org/) packages,
-   which are necessary in order to run the exercise tests:
+4. Install and use interactive shell
+
+   A summary of [Setting up and using `utop`](https://dev.realworldocaml.org/install.html):
 
    ```bash
-   opam install base core_kernel ounit
+   opam install utop
    ```
 
+   Place the following in the file `.ocamlinit` in your home directory should contain something like:
+
+   ```ocaml
+   #use "topfind";;
+   #require "base";;
+   open Base
+   ```

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -7,47 +7,33 @@ Techies love their TLA (Three Letter Acronyms)!
 Help generate some jargon by writing a program that converts a long name
 like Portable Network Graphics to its acronym (PNG).
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Julien Vanier [https://github.com/monkbroc](https://github.com/monkbroc)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -31,43 +31,29 @@ I think you got the idea!
 
 *Yes. Those three numbers above are exactly the same. Congratulations!*
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -29,51 +29,33 @@ allergens that score 256, 512, 1024, etc.).  Your program should
 ignore those components of the score.  For example, if the allergy
 score is 257, your program should only report the eggs (1) allergy.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `QCheck`. Install it using `opam`:
-
-```bash
-opam install qcheck
-```
-
-[QCheck](https://github.com/c-cube/qcheck) is a
-[property-based](https://hypothesis.works/articles/what-is-property-based-testing/)
-testing framework for Ocaml.
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Jumpstart Lab Warm-up [http://jumpstartlab.com](http://jumpstartlab.com)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -6,47 +6,33 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 "inlets" "banana"` the program should return a list containing
 `"inlets"`.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -47,47 +47,33 @@ See [String documentation](http://caml.inria.fr/pub/docs/manual-ocaml/libref/Str
 for more useful functions.
 
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -320,47 +320,33 @@ are some additional things you could try:
 Then please share your thoughts in a comment on the submission. Did this
 experiment make the code better? Worse? Did you learn anything from it?
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Learn to Program by Chris Pine [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -34,47 +34,33 @@ A binary search halves the number of items to check with each iteration,
 so locating an item (or determining its absence) takes logarithmic time.
 A binary search is a dichotomic divide and conquer search algorithm.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Wikipedia [http://en.wikipedia.org/wiki/Binary_search_algorithm](http://en.wikipedia.org/wiki/Binary_search_algorithm)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -13,6 +13,8 @@ anything.
 
 He answers 'Whatever.' to anything else.
 
+Bob's conversational partner is a purist when it comes to written communication and always follows normal rules regarding sentence punctuation in English.
+
 ## Error: No implementations provided for the following modules:
          Str referenced from bob.cmx
 
@@ -42,47 +44,33 @@ test.native: *.ml *.mli
 Note the additional `-pkg str` option.
 
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -60,47 +60,33 @@ support two operations:
 * `score() : int` is called only at the very end of the game.  It
   returns the total score for that game.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Bowling Game Kata at but UncleBob [http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata](http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -6,9 +6,9 @@ that the sum of the coins' value would equal the correct amount of change.
 ## For example
 
 - An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5)
-  and one dime (10) or [0, 1, 1, 0, 0]
+  and one dime (10) or [5, 10]
 - An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5)
-  and one dime (10) and one quarter (25) or [0, 1, 1, 1, 0]
+  and one dime (10) and one quarter (25) or [5, 10, 25]
 
 ## Edge cases
 
@@ -16,47 +16,33 @@ that the sum of the coins' value would equal the correct amount of change.
 - Can you ask for negative change?
 - Can you ask for a change value smaller than the smallest coin value?
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Software Craftsmanship - Coin Change Kata [https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata](https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -30,43 +30,29 @@ the representation passed to your code):
 the above example `O` has made a connection from left to right but nobody has
 won since `O` didn't connect top and bottom.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -7,43 +7,29 @@ type, like a set. In this exercise you will define your own set. How it
 works internally doesn't matter, as long as it behaves like a set of
 unique elements.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -12,47 +12,37 @@ Hence the difference between the square of the sum of the first
 ten natural numbers and the sum of the squares of the first ten
 natural numbers is 3025 - 385 = 2640.
 
+You are not expected to discover an efficient solution to this yourself from
+first principles; research is allowed, indeed, encouraged. Finding the best
+algorithm for the problem is a key skill in software engineering.
+
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -4,8 +4,8 @@ Make a chain of dominoes.
 
 Compute a way to order a given set of dominoes in such a way that they form a
 correct domino chain (the dots on one half of a stone match the dots on the
-neighbouring half of an adjacent stone) and that dots on the halfs of the stones
-which don't have a neighbour (the first and last stone) match each other.
+neighbouring half of an adjacent stone) and that dots on the halves of the
+stones which don't have a neighbour (the first and last stone) match each other.
 
 For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
 like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.
@@ -14,43 +14,29 @@ For stones `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1]
 
 Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -46,47 +46,33 @@ variety of languages, each with its own unique scoring table. For
 example, an "E" is scored at 2 in the Māori-language version of the
 game while being scored at 4 in the Hawaiian-language version.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -25,43 +25,29 @@ enough.)
 
 Words are case-insensitive.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -22,47 +22,33 @@ In the end, you should be able to:
 Note that all our students only have one name.  (It's a small town, what
 do you want?)
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 A pairing session with Phil Battos at gSchool [http://gschool.it](http://gschool.it)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,81 +1,55 @@
 # Hamming
 
-Calculate the Hamming difference between two DNA strands.
+Calculate the Hamming Distance between two DNA strands.
 
-A mutation is simply a mistake that occurs during the creation or
-copying of a nucleic acid, in particular DNA. Because nucleic acids are
-vital to cellular functions, mutations tend to cause a ripple effect
-throughout the cell. Although mutations are technically mistakes, a very
-rare mutation may equip the cell with a beneficial attribute. In fact,
-the macro effects of evolution are attributable by the accumulated
-result of beneficial microscopic mutations over many generations.
+Your body is made up of cells that contain DNA. Those cells regularly wear out and need replacing, which they achieve by dividing into daughter cells. In fact, the average human body experiences about 10 quadrillion cell divisions in a lifetime!
 
-The simplest and most common type of nucleic acid mutation is a point
-mutation, which replaces one base with another at a single nucleotide.
+When cells divide, their DNA replicates too. Sometimes during this process mistakes happen and single pieces of DNA get encoded with the incorrect information. If we compare two strands of DNA and count the differences between them we can see how many mistakes occurred. This is known as the "Hamming Distance".
 
-By counting the number of differences between two homologous DNA strands
-taken from different genomes with a common ancestor, we get a measure of
-the minimum number of point mutations that could have occurred on the
-evolutionary path between the two strands.
-
-This is called the 'Hamming distance'.
-
-It is found by comparing two DNA strands and counting how many of the
-nucleotides are different from their equivalent in the other string.
+We read DNA using the letters C,A,G and T. Two strands might look like this:
 
     GAGCCTACTAACGGGAT
     CATCGTAATGACGGCCT
     ^ ^ ^  ^ ^    ^^
 
-The Hamming distance between these two DNA strands is 7.
+They have 7 differences, and therefore the Hamming Distance is 7.
+
+The Hamming Distance is useful for lots of things in science, not just biology, so it's a nice phrase to be familiar with :)
 
 # Implementation notes
 
-The Hamming distance is only defined for sequences of equal length. This means
-that based on the definition, each language could deal with getting sequences
-of equal length differently.
+The Hamming distance is only defined for sequences of equal length, so
+an attempt to calculate it between sequences of different lengths should
+not work. The general handling of this situation (e.g., raising an
+exception vs returning a special value) may differ between languages.
+
 
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hangman/README.md
+++ b/exercises/hangman/README.md
@@ -17,43 +17,29 @@ be described in the language/track specific files of the exercise.
 [Hangman]: https://en.wikipedia.org/wiki/Hangman_%28game%29
 [frp]: https://en.wikipedia.org/wiki/Functional_reactive_programming
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam`, `Base` and `React`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base and react:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base react
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -14,47 +14,33 @@ The objectives are simple:
 
 If everything goes well, you will be ready to fetch your first real exercise.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -7,47 +7,33 @@ teal: 008080, navy: 000080).
 
 The program should handle invalid hexadecimal strings.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 All of Computer Science [http://www.wolframalpha.com/examples/NumberBases.html](http://www.wolframalpha.com/examples/NumberBases.html)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -13,9 +13,6 @@ on every year that is evenly divisible by 4
 For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
 year, but 2000 is.
 
-If your language provides a method in the standard library that does
-this look-up, pretend it doesn't exist and implement it yourself.
-
 ## Notes
 
 Though our exercise adopts some very simple rules, there is more to
@@ -26,47 +23,33 @@ phenomenon, go watch [this youtube video][video].
 
 [video]: http://www.youtube.com/watch?v=xX96xng7sAE
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -6,43 +6,42 @@ In functional languages list operations like `length`, `map`, and
 `reduce` are very common. Implement a series of basic list operations,
 without using existing functions.
 
+The precise number and names of the operations to be implemented will be 
+track dependent to avoid conflicts with existing names, but the general
+operations you will implement include:
+
+* `append` (*given two lists, add all items in the second list to the end of the first list*);
+* `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
+* `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
+* `length` (*given a list, return the total number of items within it*);
+* `map` (*given a function and a list, return the list of the results of applying `function(item)` on all items*);
+* `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `function(accumulator, item)`*);
+* `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);
+* `reverse` (*given a list, return a list with all the original items, but in reversed order*);
+
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -64,47 +64,33 @@ Sum the digits
 
 57 is not evenly divisible by 10, so this number is not valid.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/matching-brackets/README.md
+++ b/exercises/matching-brackets/README.md
@@ -1,49 +1,36 @@
 # Matching Brackets
 
-Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
-verify that all the pairs are matched and nested correctly.
+Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
+or any combination thereof, verify that any and all pairs are matched
+and nested correctly.
+
 
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Ginna Baker
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -26,47 +26,33 @@ Given examples of a meetup dates, each containing a month, day, year, and
 descriptor calculate the date of the actual meetup.  For example, if given
 "The first Monday of January 2017", the correct meetup date is 2017/1/2.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Core_kernel`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install core\_kernel:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install core_kernel
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month [https://twitter.com/copiousfreetime](https://twitter.com/copiousfreetime)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -26,43 +26,29 @@ into this:
     | 111 |
     +-----+
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,77 +1,44 @@
 # Nucleotide Count
 
-Given a single-stranded DNA string, compute how many times each nucleotide
-occurs in the string.
+Given a single stranded DNA string, compute how many times each nucleotide occurs in the string.
 
-The genetic language of every living thing on the planet is DNA.  DNA is a
-large molecule that is built from an extremely long sequence of individual
-elements called nucleotides.  Four types exist in DNA and these differ only
-slightly and can be represented as the following symbols:
+The genetic language of every living thing on the planet is DNA.
+DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides.
+4 types exist in DNA and these differ only slightly and can be represented as the following symbols: 'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' thymine.
 
-- `'A'` for Adenine,
-- `'C'` for Cytosine,
-- `'G'` for Guanine, and
-- `'T'` for Thymine.
+Here is an analogy:
+- twigs are to birds nests as
+- nucleotides are to DNA as
+- legos are to lego houses as
+- words are to sentences as...
 
-Since not all `char` are valid nucleotides and not all `string` are valid
-DNA strings, part of this exercise is to only give a result for meaningful
-input. See [Real World Ocaml Chapter 7. Error Handling][rwo7] for more
-information.
-
-[rwo7]: https://v1.realworldocaml.org/v1/en/html/error-handling.html
-
-The exercise consists of two parts:
-- Given an input DNA string and a nucleotide, count the number of times the
-  nucleotide occurs in the string.  If the nucleotide `c` is invalid, or the
-  DNA string contains an invalid nucleotide `c`, the result should be `Error c`.
-- Given an input DNA string, count all the nucleotides in the string and
-  gather the result in a `Map`.  If the DNA string contains an invalid
-  nucleotide `c`, the result should be `Error c`.  Otherwise the result
-  should be `Ok map`.
-
-See `test.ml` for examples.
 
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -36,47 +36,33 @@ Given the range `[10, 99]` (both inclusive)...
 The smallest palindrome product is `121`. Its factors are `(11, 11)`.
 The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Problem 4 at Project Euler [http://projecteuler.net/problem=4](http://projecteuler.net/problem=4)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -8,47 +8,33 @@ The best known English pangram is:
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
 insensitive. Input will not contain non-ASCII symbols.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -28,47 +28,33 @@ should all produce the output
 
 **Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -29,47 +29,33 @@ You can check this yourself:
 - = 60
 - Success!
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Prime Factors Kata by Uncle Bob [http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata](http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -17,47 +17,33 @@ Convert a number to a string, the contents of which depend on the number's facto
 - 34 has four factors: 1, 2, 17, and 34.
   - In raindrop-speak, this would be "34".
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -15,43 +15,29 @@ In addition, compute cells should allow for registering change notification
 callbacks.  Call a cell’s callbacks when the cell’s value in a new stable
 state has changed from the previous stable state.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -63,43 +63,29 @@ The above diagram contains 6 rectangles:
 You may assume that the input is always a proper rectangle (i.e. the length of
 every line equals the length of the first line).
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -18,47 +18,33 @@ each nucleotide with its complement:
 * `T` -> `A`
 * `A` -> `U`
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -15,47 +15,33 @@ The names must be random: they should not follow a predictable sequence.
 Random names means a risk of collisions. Your solution must ensure that
 every existing robot has a unique name.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -42,47 +42,33 @@ In Roman numerals 1990 is MCMXC:
 
 See also: http://www.novaroma.org/via_romana/numbers.html
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -23,47 +23,33 @@ the letters A through Z (either lower or upper case) and whitespace. This way
 data to be encoded will never contain any numbers and numbers inside data to
 be decoded always represent the count for the following character.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -24,7 +24,7 @@ Some good test cases for this program are:
 ### Extension
 
 If you're on a Mac, shell out to Mac OS X's `say` program to talk out
-loud.
+loud. If you're on Linux or Windows, eSpeakNG may be available with the command `espeak`.
 
 ## Step 2
 
@@ -62,47 +62,33 @@ Use _and_ (correctly) when spelling out the number in English:
 - 1002 becomes "one thousand and two".
 - 1323 becomes "one thousand three hundred and twenty-three".
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -17,47 +17,33 @@ be able to say that they're 31.69 Earth-years old.
 If you're wondering why Pluto didn't make the cut, go watch [this
 youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -22,47 +22,33 @@ The case where the sum of the lengths of two sides _equals_ that of the
 third is known as a _degenerate_ triangle - it has zero area and looks like
 a single line. Feel free to add your own code/tests to check for degenerate triangles.
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -11,47 +11,33 @@ come: 1
 free: 1
 ```
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 
 ## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
 
 If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
 
 ## Source
 
 This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
 
-## Submitting Incomplete Solutions
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -27,43 +27,29 @@ list of child nodes) a zipper might support these operations:
   `next` node if possible otherwise to the `prev` node if possible,
   otherwise to the parent node, returns a new zipper)
 
+
 ## Getting Started
-For installation and learning resources, refer to the
-[exercism help page](http://exercism.io/languages/ocaml).
+1. [Install the Exercism CLI](https://exercism.io/cli-walkthrough).
 
-## Installation
-To work on the exercises, you will need `Opam` and `Base`. Consult [opam](https://opam.ocaml.org) website for instructions on how to install `opam` for your OS. Once `opam` is installed open a terminal window and run the following command to install base:
+2. [Install OCaml](https://exercism.io/tracks/ocaml/installation).
 
-```bash
-opam install base
-```
-
-To run the tests you will need `OUnit`. Install it using `opam`:
-
-```bash
-opam install ounit
-```
+3. For library documentation, follow [Useful OCaml resources](https://exercism.io/tracks/ocaml/resources).
 
 ## Running Tests
-A Makefile is provided with a default target to compile your solution and run the tests. At the command line, type:
+A `Makefile` is provided with a default target to compile your solution and run the tests. At the command line, type:
 
 ```bash
 make
 ```
 
-## Interactive Shell
-`utop` is a command line program which allows you to run Ocaml code interactively. The easiest way to install it is via opam:
-```bash
-opam install utop
-```
-Consult [utop](https://github.com/diml/utop/blob/master/README.md) for more detail.
-
-## Feedback, Issues, Pull Requests
-The [exercism/ocaml](https://github.com/exercism/ocaml) repository on
-GitHub is the home for all of the Ocaml exercises.
-
-If you have feedback about an exercise, or want to help implementing a new
-one, head over there and create an issue.  We'll do our best to help you!
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+
+## Feedback, Issues, Pull Requests
+The [exercism/ocaml](https://github.com/exercism/ocaml) repository on GitHub is
+the home for all of the Ocaml exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue or submit a PR. We welcome new
+contributors!
+


### PR DESCRIPTION
I've changed the README template for OCaml track in the following ways:
    
 - The 'Getting Started' section has two new sections, 'installing the 
   CLI' and 'installing OCaml' listed before 'learning resources'. This
   last link is updated so that it's no longer broken.
    
 - The 'Submitting Incomplete Solutions' section is moved up below, as
   this section is easily overlooked and potentially critical to those
   who fail to get started.
    
 - The 'Installation' section is removed in favor of INSTALLATION.md
   (linked to in 'Getting Started'). Some arguments are provided:
    
   1. This section is only useful the first time you sit down. If
      you leave Exercism and come back at a much later time, this
      may be necessary again, but at this point the INSTALLATION.md
      resource is still available, linked to in 'Getting Started'.
    
   2. This description was out of sync with INSTALLATION.md. Having
      two separate descriptions seems less useful.
    
   3. The Ruby track does not mention installation instructions in their
      'Getting Started' section, and skips directly to testing. The test
      section in the OCaml track is quite limited, though.
    
 - The 'Interactive Shell' section is moved to INSTALLATION.md.
    
 - INSTALLATION.md is updated to suggest 4.08.0 instead of 4.07.0,
   and the description of `utop` has a suggested `.ocamlinit` snippet
   that is tailored for the use of Base (which Exercism uses mostly)
   rather than Core (which Real World OCaml promotes as its default).
   QCheck is added under 'test libraries'.
