### PR TITLE
test-generator: prepare ci automation

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,0 @@
-sudo apk add m4 linux-headers
-opam pin add base v0.11.1
-opam install dune ocamlfind core ounit qcheck react ppx_deriving 
-eval $(opam env)
-make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ services:
   - docker
 
 script:
-  - docker run -w /repo -v $(pwd):/repo --entrypoint "/bin/bash" -it ocaml/opam2:alpine-3.9-ocaml-4.07 ".travis-ci.sh"
+  - docker build -t ci -f .travis/Dockerfile .
+  - docker run -w /repo -v $(pwd):/repo -it ci .travis/.travis-ci.sh
+
+after_script:
   - bin/fetch-configlet
   - bin/configlet lint .
-
-env:
-  - OCAML_VERSION=4.07.0 OPAM_VERSION=1.2.2

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+eval $(opam env)
+
+sudo git clone https://github.com/exercism/problem-specifications.git /problem-specifications
+cd /problem-specifications
+sudo git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
+cd /repo/tools/test-generator
+sudo dune exec ./test_gen.exe --profile=release
+cd /repo
+sudo ocp-indent -i exercises/**/test.ml
+
+# Remove checkout line for tests with adapted 
+# special cases and implementations
+sudo git checkout -- exercises/acronym/test.ml
+sudo git checkout -- exercises/all-your-base/test.ml
+sudo git checkout -- exercises/anagram/test.ml
+sudo git checkout -- exercises/atbash-cipher/test.ml
+sudo git checkout -- exercises/beer-song/test.ml
+sudo git checkout -- exercises/binary-search/test.ml
+sudo git checkout -- exercises/bob/test.ml
+sudo git checkout -- exercises/bowling/test.ml
+sudo git checkout -- exercises/change/test.ml
+sudo git checkout -- exercises/connect/test.ml
+sudo git checkout -- exercises/difference-of-squares/test.ml
+sudo git checkout -- exercises/dominoes/test.ml
+sudo git checkout -- exercises/etl/test.ml
+sudo git checkout -- exercises/forth/test.ml
+sudo git checkout -- exercises/hamming/test.ml
+sudo git checkout -- exercises/hello-world/test.ml
+sudo git checkout -- exercises/leap/test.ml
+sudo git checkout -- exercises/luhn/test.ml
+sudo git checkout -- exercises/minesweeper/test.ml
+sudo git checkout -- exercises/palindrome-products/test.ml
+sudo git checkout -- exercises/pangram/test.ml
+sudo git checkout -- exercises/phone-number/test.ml
+sudo git checkout -- exercises/prime-factors/test.ml
+sudo git checkout -- exercises/raindrops/test.ml
+sudo git checkout -- exercises/rectangles/test.ml
+sudo git checkout -- exercises/roman-numerals/test.ml
+sudo git checkout -- exercises/run-length-encoding/test.ml
+sudo git checkout -- exercises/say/test.ml
+sudo git checkout -- exercises/space-age/test.ml
+sudo git checkout -- exercises/triangle/test.ml
+sudo git checkout -- exercises/word-count/test.ml
+
+# if output=$(git status --porcelain -- "exercises/**/test.ml") && [ -z "$output" ]; then
+#  echo "Tests are in sync."
+# else
+#  echo "Checked in test files diverged from generated files:"
+#  echo $output
+#   exit 1
+# fi
+
+make test

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,4 @@
+FROM ocaml/opam2:alpine-3.9-ocaml-4.07
+
+RUN sudo apk add m4 linux-headers
+RUN opam install dune ocamlfind core ounit qcheck react ppx_deriving yojson ounit ocp-indent

--- a/exercises/anagram/example.ml
+++ b/exercises/anagram/example.ml
@@ -7,5 +7,5 @@ let anagrams target candidates =
   let target_sorted = to_sorted_list target_lc in
   List.map ~f:(fun c -> (c, String.lowercase c)) candidates
   |> List.filter ~f:(fun (_, lc) ->
-      List.equal ~equal:Char.equal (to_sorted_list lc) target_sorted && String.(lc <> target_lc))
+      List.equal Char.equal (to_sorted_list lc) target_sorted && String.(lc <> target_lc))
   |> List.map ~f:fst

--- a/exercises/hamming/example.ml
+++ b/exercises/hamming/example.ml
@@ -1,4 +1,5 @@
 open Base
+open List.Or_unequal_lengths
 
 type nucleotide = A | C | G | T
 
@@ -10,4 +11,6 @@ let equal (x,y) = match (x, y) with
 | _ -> false
 
 let hamming_distance a b =
-  List.zip a b |> Option.map ~f:(List.count ~f:(Fn.non equal))
+  List.zip a b 
+  |> function Unequal_lengths -> None | Ok l -> Some l 
+  |> Option.map ~f:(List.count ~f:(Fn.non equal))

--- a/exercises/minesweeper/test.ml
+++ b/exercises/minesweeper/test.ml
@@ -12,7 +12,7 @@ let format_board strings =
 
 (* Assert Equals *)
 let ae exp got =
-  assert_equal exp got ~cmp:(List.equal ~equal:String.equal) ~printer:format_board
+  assert_equal exp got ~printer:format_board
 
 let tests = [
   "no rows" >:: (fun _ ->

--- a/tools/test-generator/src/ocaml_special_cases.ml
+++ b/tools/test-generator/src/ocaml_special_cases.ml
@@ -44,7 +44,7 @@ let option_of_null (value: json): string = match value with
 | `Null -> "None"
 | `String s -> "(Some \"" ^ s ^ "\")"
 | `List xs as l -> "(Some " ^ (json_to_string l) ^ ")"
-| _ -> failwith "cannot handle this type"
+| x -> failwith "cannot handle this type: " ^ json_to_string x
 
 let is_empty_string (value: json): bool = match value with
 | `String s -> String.is_empty s
@@ -58,6 +58,7 @@ let edit_connect_expected = function
 
 let edit_change_expected (value: json) = match value with
 | `List xs -> "(Some [" ^ (String.concat ~sep:"; " (List.map ~f:json_to_string xs)) ^ "])"
+| `Assoc [("error", _)] -> "None"
 | `Int (-1) -> "None"
 | _ -> failwith "Bad json value in change"
 
@@ -147,10 +148,10 @@ let ocaml_edit_parameters ~(slug: string) (parameters: (string * json) list) = m
 | ("change", ps) -> edit_expected ~f:edit_change_expected ps
 | ("connect", ps) -> edit_expected ~f:edit_connect_expected ps
 | ("dominoes", ps) -> edit_dominoes ps
-| ("forth", ps) -> edit_expected ~f:option_of_null ps
+(* | ("forth", ps) -> edit_expected ~f:option_of_null ps *)
 | ("hamming", ps) -> edit_expected ~f:(optional_int ~none:(-1)) ps
 | ("palindrome-products", ps) -> edit_palindrome_products ps
-| ("phone-number", ps) -> edit_expected ~f:option_of_null ps
+(* | ("phone-number", ps) -> edit_expected ~f:option_of_null ps *)
 | ("say", ps) -> edit_say ps
 | ("space-age", ps) -> edit_space_age ps
 | (_, ps) -> map_elements json_to_string ps

--- a/tools/test-generator/templates/ocaml/forth/test.ml
+++ b/tools/test-generator/templates/ocaml/forth/test.ml
@@ -10,7 +10,7 @@ let ae exp got _test_ctxt = assert_equal ~printer:print_int_list_option exp got
 let (* SUITE parsing_and_numbers *)parsing_and_numbers_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -18,7 +18,7 @@ let (* SUITE parsing_and_numbers *)parsing_and_numbers_tests = [
 let (* SUITE addition *)addition_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -26,7 +26,7 @@ let (* SUITE addition *)addition_tests = [
 let (* SUITE subtraction *)subtraction_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -34,7 +34,7 @@ let (* SUITE subtraction *)subtraction_tests = [
 let (* SUITE multiplication *)multiplication_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -42,7 +42,7 @@ let (* SUITE multiplication *)multiplication_tests = [
 let (* SUITE division *)division_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -50,7 +50,7 @@ let (* SUITE division *)division_tests = [
 let (* SUITE combined_arithmetic *)combined_arithmetic_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -58,7 +58,7 @@ let (* SUITE combined_arithmetic *)combined_arithmetic_tests = [
 let (* SUITE dup *)dup_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -66,7 +66,7 @@ let (* SUITE dup *)dup_tests = [
 let (* SUITE drop *)drop_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -74,7 +74,7 @@ let (* SUITE drop *)drop_tests = [
 let (* SUITE swap *)swap_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -82,7 +82,7 @@ let (* SUITE swap *)swap_tests = [
 let (* SUITE over *)over_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -90,7 +90,15 @@ let (* SUITE over *)over_tests = [
 let (* SUITE user-defined_words *)user_defined_words_tests = [
 (* TEST
    "$description" >::
-     ae $expected (evaluate $input);
+     ae $expected (evaluate $instructions);
+   END TEST *)
+]
+(* END SUITE *)
+
+let (* SUITE case-insensitivity *)case_insensitivity = [
+(* TEST
+   "$description" >::
+     ae $expected (evaluate $instructions);
    END TEST *)
 ]
 (* END SUITE *)
@@ -109,6 +117,7 @@ let () =
         drop_tests;
         swap_tests; 
         over_tests; 
-        user_defined_words_tests
+        user_defined_words_tests;
+        case_insensitivity;
         ]
   )

--- a/tools/test-generator/templates/ocaml/minesweeper/test.ml
+++ b/tools/test-generator/templates/ocaml/minesweeper/test.ml
@@ -12,7 +12,7 @@ let format_board strings =
 
 (* Assert Equals *)
 let ae exp got =
-  assert_equal exp got ~cmp:(List.equal ~equal:String.equal) ~printer:format_board
+  assert_equal exp got ~printer:format_board
 
 let tests = [
 (* TEST

--- a/tools/test-generator/templates/ocaml/triangle/test.ml
+++ b/tools/test-generator/templates/ocaml/triangle/test.ml
@@ -4,21 +4,21 @@ open Triangle
 
 let ae exp got _test_ctxt = assert_equal exp got ~printer:Bool.to_string
 
-let (* SUITE returns_true_if_the_triangle_is_equilateral *)equilateral_tests = [
+let (* SUITE equilateral_triangle *)equilateral_tests = [
 (* TEST
    "$description" >::
      ae $expected (is_equilateral $sides);
    END TEST *)
 ]
 (* END SUITE *)
-let (* SUITE returns_true_if_the_triangle_is_isosceles *)isosceles_tests = [
+let (* SUITE isosceles_triangle *)isosceles_tests = [
 (* TEST
    "$description" >::
      ae $expected (is_isosceles $sides);
    END TEST *)
 ]
 (* END SUITE *)
-let (* SUITE returns_true_if_the_triangle_is_scalene *)scalene_tests = [
+let (* SUITE scalene_triangle *)scalene_tests = [
 (* TEST
    "$description" >::
      ae $expected (is_scalene $sides);


### PR DESCRIPTION
* Depends on #314 
* Execute `test-generator` on  CI to test it compiles and executes
* Run `ocp-indent` 
* Reset generated test files to avoid test breakage 
* Adapt `anagram/example` to Base 0.12
* Adapt `hamming/example` to Base 0.12
* Adapt `minesweeper/test` to Base 0.12
---
I opted for explicit resets of files that would be written by `test_generator`. 
This allows me to adapt the exercise-specific generator code, `*.mli` and `example.ml` files for only one exercise at a time while keeping the CI green.