### PR TITLE
binary-search: adapt to new Result interface 

### DIFF
--- a/exercises/binary-search/binary_search.mli
+++ b/exercises/binary-search/binary_search.mli
@@ -1,2 +1,4 @@
+open Base
+
 (* Finds an int in an array of ints via binary search *)
-val find : int array -> int -> int option
+val find : int array -> int -> (int, string) Result.t

--- a/exercises/binary-search/example.ml
+++ b/exercises/binary-search/example.ml
@@ -2,7 +2,7 @@ open Base
 
 let find xs value = 
   let rec go lo hi = 
-    if lo > hi then None
+    if lo > hi then Error "value not in array"
     else begin 
       let mid = lo + (hi - lo) / 2 in
       let mid_val = xs.(mid) in
@@ -10,10 +10,10 @@ let find xs value =
       then go (mid + 1) hi
       else if mid_val > value
       then go lo (mid - 1)
-      else Some mid
+      else Ok mid
     end
   in
   if Array.is_empty xs
-  then None
+  then Error "value not in array"
   else go 0 (Array.length xs - 1) 
   

--- a/exercises/binary-search/test.ml
+++ b/exercises/binary-search/test.ml
@@ -1,34 +1,36 @@
 open OUnit2
 open Binary_search
 
-let option_to_string f = function
-  | None   -> "None"
-  | Some x -> "Some " ^ f x
+let result_to_string f = function
+  | Error m -> Printf.sprintf "Error \"%s\"" m
+  | Ok x -> f x |> Printf.sprintf "Some %s"
 
 let ae exp got _test_ctxt =
-  assert_equal ~printer:(option_to_string string_of_int) exp got
+  assert_equal ~printer:(result_to_string string_of_int) exp got
 
 let tests = [
   "finds a value in an array with one element" >::
-    ae (Some 0) (find [|6|] 6);
+  ae (Ok 0) (find [|6|] 6);
   "finds a value in the middle of an array" >::
-    ae (Some 3) (find [|1; 3; 4; 6; 8; 9; 11|] 6);
+  ae (Ok 3) (find [|1; 3; 4; 6; 8; 9; 11|] 6);
   "finds a value at the beginning of an array" >::
-    ae (Some 0) (find [|1; 3; 4; 6; 8; 9; 11|] 1);
+  ae (Ok 0) (find [|1; 3; 4; 6; 8; 9; 11|] 1);
   "finds a value at the end of an array" >::
-    ae (Some 6) (find [|1; 3; 4; 6; 8; 9; 11|] 11);
+  ae (Ok 6) (find [|1; 3; 4; 6; 8; 9; 11|] 11);
   "finds a value in an array of odd length" >::
-    ae (Some 9) (find [|1; 3; 5; 8; 13; 21; 34; 55; 89; 144; 233; 377; 634|] 144);
+  ae (Ok 9) (find [|1; 3; 5; 8; 13; 21; 34; 55; 89; 144; 233; 377; 634|] 144);
   "finds a value in an array of even length" >::
-    ae (Some 5) (find [|1; 3; 5; 8; 13; 21; 34; 55; 89; 144; 233; 377|] 21);
+  ae (Ok 5) (find [|1; 3; 5; 8; 13; 21; 34; 55; 89; 144; 233; 377|] 21);
   "identifies that a value is not included in the array" >::
-    ae None (find [|1; 3; 4; 6; 8; 9; 11|] 7);
-  "a value smaller than the array's smallest value is not included" >::
-    ae None (find [|1; 3; 4; 6; 8; 9; 11|] 0);
-  "a value larger than the array's largest value is not included" >::
-    ae None (find [|1; 3; 4; 6; 8; 9; 11|] 13);
-  "nothing is included in an empty array" >::
-    ae None (find [||] 1);
+  ae (Error "value not in array") (find [|1; 3; 4; 6; 8; 9; 11|] 7);
+  "a value smaller than the array's smallest value is not found" >::
+  ae (Error "value not in array") (find [|1; 3; 4; 6; 8; 9; 11|] 0);
+  "a value larger than the array's largest value is not found" >::
+  ae (Error "value not in array") (find [|1; 3; 4; 6; 8; 9; 11|] 13);
+  "nothing is found in an empty array" >::
+  ae (Error "value not in array") (find [||] 1);
+  "nothing is found when the left and right bounds cross" >::
+  ae (Error "value not in array") (find [|1; 2|] 0);
 ]
 
 let () =

--- a/tools/test-generator/src/ocaml_special_cases.ml
+++ b/tools/test-generator/src/ocaml_special_cases.ml
@@ -132,7 +132,8 @@ let edit_binary_search (ps: (string * json) list): (string * string) list =
     "[|" ^ String.concat ~sep:"; " xs ^ "|]" in
   let edit = function
   | ("array", v) -> ("array", as_array_string v) 
-  | ("expected", v) -> ("expected", optional_int ~none:(-1) v)
+  | ("expected", `Int i) -> ("expected", Printf.sprintf "(Ok %i)" i)
+  | ("expected", `Assoc [("error", `String m)]) -> ("expected", Printf.sprintf "(Error \"%s\")" m)
   | (k, v) -> (k, json_to_string v) in
   List.map ps ~f:edit
 

--- a/tools/test-generator/templates/ocaml/binary-search/test.ml
+++ b/tools/test-generator/templates/ocaml/binary-search/test.ml
@@ -1,12 +1,12 @@
 open OUnit2
 open Binary_search
 
-let option_to_string f = function
-  | None   -> "None"
-  | Some x -> "Some " ^ f x
+let result_to_string f = function
+  | Error m -> Printf.sprintf "Error \"%s\"" m
+  | Ok x -> f x |> Printf.sprintf "Some %s"
 
 let ae exp got _test_ctxt =
-  assert_equal ~printer:(option_to_string string_of_int) exp got
+  assert_equal ~printer:(result_to_string string_of_int) exp got
 
 let tests = [
 (* TEST


### PR DESCRIPTION
* Depends #312, #313 
* Changes `binary_search` from `int array -> int -> int option` to `int array -> int -> (int, string) Base.Result.t`

---

The underlying issue here was that the `optional_int` transformation in `test_generator` failed because the `{ error: "error message" }` objects introduced in `problem-specifications` were not supported. Investigating further I though it would be good to model closer to the semantics of `problem-specifications` and change from `option` to `Base.Result.t`.