### PR TITLE
 bowling: sync with new test data 

### DIFF
--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -20,7 +20,7 @@ sudo git checkout -- exercises/atbash-cipher/test.ml
 sudo git checkout -- exercises/beer-song/test.ml
 sudo git checkout -- exercises/binary-search/test.ml
 sudo git checkout -- exercises/bob/test.ml
-sudo git checkout -- exercises/bowling/test.ml
+# sudo git checkout -- exercises/bowling/test.ml
 sudo git checkout -- exercises/change/test.ml
 sudo git checkout -- exercises/connect/test.ml
 sudo git checkout -- exercises/difference-of-squares/test.ml

--- a/tools/test-generator/src/codegen.ml
+++ b/tools/test-generator/src/codegen.ml
@@ -19,7 +19,8 @@ let replace_key (key: string) (value: string) (target: string): string =
 let rec replace_keys (ed: edit_parameters_function) (s: string) (suite_name: string) (c: case): subst =
   let s = replace_key "description" c.description s in
   let s = replace_key "suite-name" suite_name s in
-  let parameter_strings = ed @@ List.map ~f:(fun (k,p) -> (k,p)) c.parameters in
+  let s = replace_key "property" c.property s in
+  let parameter_strings = ed c.parameters in
   List.fold parameter_strings ~init:(Subst s) ~f:(fun (Subst s) (k,v) -> Subst (replace_key k v s))
 
 let fill_in_template (ed: edit_parameters_function) (test_template: string) (suite_name: string) (cases: case list) =

--- a/tools/test-generator/src/model.ml
+++ b/tools/test-generator/src/model.ml
@@ -5,7 +5,8 @@ open Yojson.Basic
 
 type case = {
   description: string;
-  parameters: (string * json) list
+  parameters: (string * json) list;
+  property: string;
 }
 
 type test = {name: string; cases: case list}

--- a/tools/test-generator/src/ocaml_special_cases.ml
+++ b/tools/test-generator/src/ocaml_special_cases.ml
@@ -123,7 +123,7 @@ let edit_bowling (ps: (string * json) list): (string * string) list =
   | ("roll", `Int n) -> ("roll", let s = Int.to_string n in if n < 0 then ("(" ^ s ^ ")") else s)
   | ("expected", v) -> ("expected", edit_bowling_expected v)
   | (k, v) -> (k, json_to_string v) in
-  List.map ps ~f:edit
+  (List.map ps ~f:edit) @ if List.exists ps ~f:(fun (k, _) -> String.equal "roll" k) then [] else [("roll", "")]
 
 let edit_binary_search (ps: (string * json) list): (string * string) list =
   let open Yojson.Basic.Util in

--- a/tools/test-generator/src/parser.ml
+++ b/tools/test-generator/src/parser.ml
@@ -6,7 +6,7 @@ open Model
 
 type error =
     TestMustHaveKeyCalledCases of string | ExpectingListOfCases | ExpectingMapForCase |
-    NoDescription | BadDescription | UnrecognizedJson [@@deriving eq, show]
+    NoDescription | BadDescription | NoProperty | BadProperty | UnrecognizedJson [@@deriving eq, show]
 
 let extract_parameters case =
   let open Result.Monad_infix in
@@ -24,7 +24,8 @@ let parse_case_assoc (parameters: (string * json) list): (case, error) Result.t 
   find "description" NoDescription >>=
   to_string_note BadDescription >>= fun description ->
   extract_parameters test_parameters >>= fun test_parameters ->
-  Ok {description = description; parameters = test_parameters}
+  find "property" NoProperty >>= to_string_note BadProperty >>= fun property ->
+  Ok {description = description; parameters = test_parameters; property = property}
 
 let parse_case (s: json): (case, error) Result.t = match s with
   | `Assoc assoc -> parse_case_assoc assoc
@@ -45,6 +46,8 @@ let parse_single (text: string) (cases_key: string): (tests, error) Result.t =
 let rec to_cases case: (case list, error) Result.t = 
   let open Result.Monad_infix in
   find_note case "description" NoDescription >>= to_string_note BadDescription >>= fun desc ->
+  let find name = List.Assoc.find case ~equal:String.equal name in
+  let property = find "property" |> Option.value_map ~default:"" ~f:(function `String s -> s | _ -> "") in
   let cases = List.Assoc.find case ~equal:String.equal "cases" in
   match cases with
   | Some cases -> 
@@ -53,7 +56,7 @@ let rec to_cases case: (case list, error) Result.t =
       List.map x ~f:to_cases |> sequence |> Result.map ~f:List.concat
   | None -> 
       extract_parameters case >>= fun parameters ->
-      Result.return [{description = desc; parameters = parameters}]
+      Result.return [{description = desc; parameters = parameters; property = property}]
 
 let convert_cases_description_to_name desc =
   String.lowercase desc |> String.substr_replace_all ~pattern:" " ~with_:"_"
@@ -93,3 +96,5 @@ let show_error = function
   | NoDescription -> "Case is missing a description."
   | BadDescription -> "Description is not a string."
   | UnrecognizedJson -> "Cannot understand this json."
+  | NoProperty -> "Case is missing a property key."
+  | BadProperty -> "Property is not a string."

--- a/tools/test-generator/templates/ocaml/bowling/test.ml
+++ b/tools/test-generator/templates/ocaml/bowling/test.ml
@@ -14,18 +14,22 @@ let set_previous_frames (frames : int list): game =
 let score_printer = function
 | Ok n -> Int.to_string n
 | Error e -> e
-let assert_score exp game = assert_equal ~printer:score_printer exp (score game)
 
 let roll_printer = function
 | Ok _ -> "Ok <some game>"
 | Error e -> e
-let assert_roll exp frame game = assert_equal ~printer:roll_printer exp (roll frame game)
+
+let assert_score frames exp = 
+  assert_equal ~printer:score_printer exp (score (set_previous_frames frames))
+
+let assert_roll frames exp frame = 
+  assert_equal ~printer:roll_printer exp (roll frame (set_previous_frames frames))
 
 let tests = [
 (* TEST
    "$description" >:: (fun _ ->
-      let g = set_previous_frames $previous_rolls in
-      assert_$property $expected $roll g
+      let rolls = $previousRolls in
+      assert_$property rolls $expected $roll
    );
    END TEST *)
 ]


### PR DESCRIPTION
* Depends on #314, #315, #318 
* Substitute `$roll` with empty string if not defined in inputs: [ocaml_special_cases.ml](https://github.com/exercism/ocaml/compare/master...marionebl:resync-bowling?expand=1#diff-6bb359a33810bb55b6e7b4e5d31d12fcR126)
* Restructure test template to accommodate `assert_roll` and `assert_score` without formatting changes