### PR TITLE
connect: achieve nice formatting automatically 

### DIFF
--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -22,7 +22,7 @@ sudo git checkout -- exercises/binary-search/test.ml
 sudo git checkout -- exercises/bob/test.ml
 sudo git checkout -- exercises/bowling/test.ml
 sudo git checkout -- exercises/change/test.ml
-sudo git checkout -- exercises/connect/test.ml
+# sudo git checkout -- exercises/connect/test.ml
 sudo git checkout -- exercises/difference-of-squares/test.ml
 sudo git checkout -- exercises/dominoes/test.ml
 sudo git checkout -- exercises/etl/test.ml

--- a/exercises/connect/test.ml
+++ b/exercises/connect/test.ml
@@ -2,118 +2,114 @@ open OUnit2
 open Connect
 
 let show_player = function
-| Some X -> "X"
-| Some O -> "O"
-| None -> "None"
+  | Some X -> "X"
+  | Some O -> "O"
+  | None -> "None"
 
 let ae exp got = assert_equal ~printer:show_player exp got
 
 let tests = [
   "an empty board has no winner" >::(fun _ctxt ->
-    let board = [
-      ". . . . ."; 
-      " . . . . ."; 
-      "  . . . . ."; 
-      "   . . . . ."; 
-      "    . . . . ."
+      let board = [
+        ". . . . .";
+        " . . . . .";
+        "  . . . . .";
+        "   . . . . .";
+        "    . . . . .";
       ] 
-    in
-    ae None (connect board)
-  );
+      in
+      ae None (connect board)
+    );
   "X can win on a 1x1 board" >::(fun _ctxt ->
-    let board = [
-      "X"
-      ] 
-    in
-    ae (Some X) (connect board)
-  );
+      let board = ["X"] 
+      in
+      ae (Some X) (connect board)
+    );
   "O can win on a 1x1 board" >::(fun _ctxt ->
-    let board = [
-      "O"
-      ] 
-    in
-    ae (Some O) (connect board)
-  );
+      let board = ["O"] 
+      in
+      ae (Some O) (connect board)
+    );
   "only edges does not make a winner" >::(fun _ctxt ->
-    let board = [
-      "O O O X"; 
-      " X . . X"; 
-      "  X . . X"; 
-      "   X O O O"
+      let board = [
+        "O O O X";
+        " X . . X";
+        "  X . . X";
+        "   X O O O";
       ] 
-    in
-    ae None (connect board)
-  );
+      in
+      ae None (connect board)
+    );
   "illegal diagonal does not make a winner" >::(fun _ctxt ->
-    let board = [
-      "X O . ."; 
-      " O X X X"; 
-      "  O X O ."; 
-      "   . O X ."; 
-      "    X X O O"
+      let board = [
+        "X O . .";
+        " O X X X";
+        "  O X O .";
+        "   . O X .";
+        "    X X O O";
       ] 
-    in
-    ae None (connect board)
-  );
+      in
+      ae None (connect board)
+    );
   "nobody wins crossing adjacent angles" >::(fun _ctxt ->
-    let board = [
-      "X . . ."; 
-      " . X O ."; 
-      "  O . X O"; 
-      "   . O . X"; 
-      "    . . O ."
+      let board = [
+        "X . . .";
+        " . X O .";
+        "  O . X O";
+        "   . O . X";
+        "    . . O .";
       ] 
-    in
-    ae None (connect board)
-  );
+      in
+      ae None (connect board)
+    );
   "X wins crossing from left to right" >::(fun _ctxt ->
-    let board = [
-      ". O . ."; 
-      " O X X X"; 
-      "  O X O ."; 
-      "   X X O X"; 
-      "    . O X ."
+      let board = [
+        ". O . .";
+        " O X X X";
+        "  O X O .";
+        "   X X O X";
+        "    . O X .";
       ] 
-    in
-    ae (Some X) (connect board)
-  );
+      in
+      ae (Some X) (connect board)
+    );
   "O wins crossing from top to bottom" >::(fun _ctxt ->
-    let board = [
-      ". O . ."; 
-      " O X X X"; 
-      "  O O O ."; 
-      "   X X O X"; 
-      "    . O X ."
+      let board = [
+        ". O . .";
+        " O X X X";
+        "  O O O .";
+        "   X X O X";
+        "    . O X .";
       ] 
-    in
-    ae (Some O) (connect board)
-  );
+      in
+      ae (Some O) (connect board)
+    );
   "X wins using a convoluted path" >::(fun _ctxt ->
-    let board = [
-      ". X X . ."; 
-      " X . X . X"; 
-      "  . X . X ."; 
-      "   . X X . ."; 
-      "    O O O O O"
+      let board = [
+        ". X X . .";
+        " X . X . X";
+        "  . X . X .";
+        "   . X X . .";
+        "    O O O O O";
       ] 
-    in
-    ae (Some X) (connect board)
-  );
+      in
+      ae (Some X) (connect board)
+    );
   "X wins using a spiral path" >::(fun _ctxt ->
-    let board = [
-      "O X X X X X X X X"; 
-      " O X O O O O O O O"; 
-      "  O X O X X X X X O"; 
-      "   O X O X O O O X O"; 
-      "    O X O X X X O X O"; 
-      "     O X O O O X O X O"; 
-      "      O X X X X X O X O"; 
-      "       O O O O O O O X O"; 
-      "        X X X X X X X X O"
+      let board = [
+        "O X X X X X X X X";
+        " O X O O O O O O O";
+        "  O X O X X X X X O";
+        "   O X O X O O O X O";
+        "    O X O X X X O X O";
+        "     O X O O O X O X O";
+        "      O X X X X X O X O";
+        "       O O O O O O O X O";
+        "        X X X X X X X X O";
       ] 
-    in
-    ae (Some X) (connect board)
-  );
+      in
+      ae (Some X) (connect board)
+    );
 ]
 
 let () =

--- a/tools/test-generator/src/ocaml_special_cases.ml
+++ b/tools/test-generator/src/ocaml_special_cases.ml
@@ -50,12 +50,6 @@ let is_empty_string (value: json): bool = match value with
 | `String s -> String.is_empty s
 | _ -> false
 
-let edit_connect_expected = function
-| `String "X" -> "(Some X)"
-| `String "O" -> "(Some O)"
-| `String "" -> "None"
-| x -> failwith "Bad json value in connect " ^ json_to_string x
-
 let edit_change_expected (value: json) = match value with
 | `List xs -> "(Some [" ^ (String.concat ~sep:"; " (List.map ~f:json_to_string xs)) ^ "])"
 | `Assoc [("error", _)] -> "None"
@@ -80,6 +74,22 @@ let edit_all_your_base (ps: (string * json) list): (string * string) list =
   | ("outputBase", v) -> let v = json_to_string v in ("outputBase", if Int.of_string v >= 0 then v else "(" ^ v ^ ")")
   | ("inputBase", v) -> let v = json_to_string v in ("inputBase", if Int.of_string v >= 0 then v else "(" ^ v ^ ")")
   | ("expected", v) -> ("expected", optional_int_list v)
+  | (k, v) -> (k, json_to_string v) in
+  List.map ps ~f:edit
+
+let edit_connect (ps: (string * json) list): (string * string) list =
+  let format_board l = 
+    if List.length l > 1 then
+      l |> List.map ~f:(json_to_string)
+        |> String.concat ~sep:";\n"
+        |> Printf.sprintf "[\n%s;\n]"
+    else json_to_string (`List l)
+  in
+  let edit = function
+  | ("expected", `String "X") -> ("expected", "(Some X)")
+  | ("expected", `String "O") -> ("expected", "(Some O)")
+  | ("expected", `String "" ) ->  ("expected", "None")
+  | ("board", `List l) -> ("board", format_board l)
   | (k, v) -> (k, json_to_string v) in
   List.map ps ~f:edit
 
@@ -146,7 +156,7 @@ let ocaml_edit_parameters ~(slug: string) (parameters: (string * json) list) = m
 | ("binary-search", ps) -> edit_binary_search ps
 | ("bowling", ps) -> edit_bowling ps
 | ("change", ps) -> edit_expected ~f:edit_change_expected ps
-| ("connect", ps) -> edit_expected ~f:edit_connect_expected ps
+| ("connect", ps) -> edit_connect ps
 | ("dominoes", ps) -> edit_dominoes ps
 (* | ("forth", ps) -> edit_expected ~f:option_of_null ps *)
 | ("hamming", ps) -> edit_expected ~f:(optional_int ~none:(-1)) ps

--- a/tools/test-generator/templates/ocaml/connect/test.ml
+++ b/tools/test-generator/templates/ocaml/connect/test.ml
@@ -1,4 +1,3 @@
-open Base
 open OUnit2
 open Connect
 


### PR DESCRIPTION
* Depends on #315
* Enhance test-generator to achieve readable formatting for board inputs
* Emit trailing ";"
* Ran `ocp-indent` on `exercises/connect/test.ml`