### PR TITLE
add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "ocaml",
+    "dockerFile": "../.travis/Dockerfile",
+    "extensions": [
+        "freebroccolo.reasonml",
+        "maelvalais.dune",
+        "hackwaly.ocaml-debugger",
+        "editorconfig.editorconfig",
+        "ms-azuretools.vscode-docker"
+    ]
+}

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -4,17 +4,17 @@ set -e
 eval $(opam env)
 
 cd /repo/tools/test-generator
-dune runtest 
+sudo dune runtest 
 
-git clone https://github.com/exercism/problem-specifications.git /problem-specifications
+sudo git clone https://github.com/exercism/problem-specifications.git /problem-specifications
 cd /problem-specifications
-git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
+sudo git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
 
 cd /repo/tools/test-generator/bin_test_gen
-dune exec ./test_gen.exe --profile=release
+sudo dune exec ./test_gen.exe --profile=release
 
 cd /repo
-ocp-indent -i exercises/**/test.ml
+sudo ocp-indent -i exercises/**/test.ml
 
 if output=$(git status --porcelain -- "exercises/**/test.ml") && [ -z "$output" ]; then
  echo "Tests are in sync."
@@ -24,4 +24,4 @@ else
  exit 1
 fi
 
-make test
+sudo make test

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -4,17 +4,17 @@ set -e
 eval $(opam env)
 
 cd /repo/tools/test-generator
-sudo dune runtest 
+dune runtest 
 
-sudo git clone https://github.com/exercism/problem-specifications.git /problem-specifications
+git clone https://github.com/exercism/problem-specifications.git /problem-specifications
 cd /problem-specifications
-sudo git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
+git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
 
 cd /repo/tools/test-generator/bin_test_gen
-sudo dune exec ./test_gen.exe --profile=release
+dune exec ./test_gen.exe --profile=release
 
 cd /repo
-sudo ocp-indent -i exercises/**/test.ml
+ocp-indent -i exercises/**/test.ml
 
 if output=$(git status --porcelain -- "exercises/**/test.ml") && [ -z "$output" ]; then
  echo "Tests are in sync."
@@ -24,4 +24,4 @@ else
  exit 1
 fi
 
-sudo make test
+make test

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -4,17 +4,17 @@ set -e
 eval $(opam env)
 
 cd /repo/tools/test-generator
-sudo dune runtest 
+dune runtest 
 
-sudo git clone https://github.com/exercism/problem-specifications.git /problem-specifications
+git clone https://github.com/exercism/problem-specifications.git /problem-specifications
 cd /problem-specifications
-sudo git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
+git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
 
 cd /repo/tools/test-generator/bin_test_gen
-sudo dune exec ./test_gen.exe --profile=release
+dune exec ./test_gen.exe --profile=release
 
 cd /repo
-sudo ocp-indent -i exercises/**/test.ml
+ocp-indent -i exercises/**/test.ml
 
 if output=$(git status --porcelain -- "exercises/**/test.ml") && [ -z "$output" ]; then
  echo "Tests are in sync."

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -2,6 +2,22 @@ FROM ocaml/opam2:ubuntu-18.04-ocaml-4.07
 
 RUN sudo apt-get update
 RUN sudo apt-get install m4 bmake cpio -y
+
+RUN cd /home/opam/opam-repository
+RUN git pull
+RUN git checkout c23c1a7071910f235d5bc173cbadb97cd450e9fb
+RUN cd -
+
+RUN opam update
 RUN opam install dune ocamlfind core ounit qcheck react ppx_deriving yojson ounit ocp-indent calendar
 
 RUN sudo apt-get install net-tools
+
+USER root
+RUN ln -s /home/opam/.opam /root/.opam
+SHELL ["/bin/bash", "--login" , "-c"]
+ENV OPAM_SWITCH_PREFIX='/root/.opam/4.07.1'
+ENV CAML_LD_LIBRARY_PATH='/root/.opam/4.07.1/lib/stublibs:/root/.opam/4.07.1/lib/ocaml/stublibs:/root/.opam/4.07.1/lib/ocaml'
+ENV OCAML_TOPLEVEL_PATH='/root/.opam/4.07.1/lib/toplevel'
+ENV MANPATH=':/root/.opam/4.07.1/man'
+ENV PATH='/root/.opam/4.07.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,4 +1,7 @@
-FROM ocaml/opam2:alpine-3.9-ocaml-4.07
+FROM ocaml/opam2:ubuntu-18.04-ocaml-4.07
 
-RUN sudo apk add m4 linux-headers
+RUN sudo apt-get update
+RUN sudo apt-get install m4 bmake cpio -y
 RUN opam install dune ocamlfind core ounit qcheck react ppx_deriving yojson ounit ocp-indent calendar
+
+RUN sudo apt-get install net-tools

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.colorCustomizations": {}
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # assignments
 ASSIGNMENT ?= ""
-ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort)
+ASSIGNMENTS = $(shell git ls-tree --name-only HEAD -- exercises/ | awk -F/ '{print $$NF}' | sort)
 
 default: testgenerator test
 


### PR DESCRIPTION
This adds configuration for Visual Studio Code Remote - Containers. Using the mentioned extension with this config allows me to develop on the OCaml track in isolation, which helps with avoiding conflicts with other OCaml based projects and maintaining `opam` switches.

Usage:

* Install [VSCode Insiders](https://code.visualstudio.com/insiders/)
* Install [Visual Studio Code Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
* Open the repo root with VSCode Insiders
* On the notification that pops on the lower right corner hit "Reopen in Container"
  
<img width="568" alt="Screenshot 2019-08-03 at 20 55 18" src="https://user-images.githubusercontent.com/4248851/62415865-0b416a80-b631-11e9-9588-7e4fd1cf0819.png">
