### PR TITLE
compile stub files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "ocaml",
+    "dockerFile": "../.travis/Dockerfile",
+    "extensions": [
+        "freebroccolo.reasonml",
+        "maelvalais.dune",
+        "hackwaly.ocaml-debugger",
+        "editorconfig.editorconfig",
+        "ms-azuretools.vscode-docker"
+    ]
+}

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -13,6 +13,8 @@ git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583
 cd /repo/tools/test-generator/bin_test_gen
 dune exec ./test_gen.exe --profile=release
 
+dune build @buildtest
+
 cd /repo
 ocp-indent -i exercises/**/test.ml
 

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -4,17 +4,17 @@ set -e
 eval $(opam env)
 
 cd /repo/tools/test-generator
-dune runtest 
+sudo dune runtest 
 
-git clone https://github.com/exercism/problem-specifications.git /problem-specifications
+sudo git clone https://github.com/exercism/problem-specifications.git /problem-specifications
 cd /problem-specifications
-git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
+sudo git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
 
 cd /repo/tools/test-generator/bin_test_gen
-dune exec ./test_gen.exe --profile=release
+sudo dune exec ./test_gen.exe --profile=release
 
 cd /repo
-ocp-indent -i exercises/**/test.ml
+sudo ocp-indent -i exercises/**/test.ml
 
 if output=$(git status --porcelain -- "exercises/**/test.ml") && [ -z "$output" ]; then
  echo "Tests are in sync."
@@ -24,4 +24,4 @@ else
  exit 1
 fi
 
-make test
+sudo make test

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -3,6 +3,9 @@ set -e
 
 eval $(opam env)
 
+cd /repo
+dune build @buildtest
+
 cd /repo/tools/test-generator
 dune runtest 
 
@@ -12,8 +15,6 @@ git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583
 
 cd /repo/tools/test-generator/bin_test_gen
 dune exec ./test_gen.exe --profile=release
-
-dune build @buildtest
 
 cd /repo
 ocp-indent -i exercises/**/test.ml

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -4,17 +4,17 @@ set -e
 eval $(opam env)
 
 cd /repo/tools/test-generator
-sudo dune runtest 
+dune runtest 
 
-sudo git clone https://github.com/exercism/problem-specifications.git /problem-specifications
+git clone https://github.com/exercism/problem-specifications.git /problem-specifications
 cd /problem-specifications
-sudo git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
+git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
 
 cd /repo/tools/test-generator/bin_test_gen
-sudo dune exec ./test_gen.exe --profile=release
+dune exec ./test_gen.exe --profile=release
 
 cd /repo
-sudo ocp-indent -i exercises/**/test.ml
+ocp-indent -i exercises/**/test.ml
 
 if output=$(git status --porcelain -- "exercises/**/test.ml") && [ -z "$output" ]; then
  echo "Tests are in sync."
@@ -24,4 +24,4 @@ else
  exit 1
 fi
 
-sudo make test
+make test

--- a/.travis/.travis-ci.sh
+++ b/.travis/.travis-ci.sh
@@ -4,17 +4,17 @@ set -e
 eval $(opam env)
 
 cd /repo/tools/test-generator
-sudo dune runtest 
+dune runtest 
 
-sudo git clone https://github.com/exercism/problem-specifications.git /problem-specifications
+git clone https://github.com/exercism/problem-specifications.git /problem-specifications
 cd /problem-specifications
-sudo git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
+git checkout 2af3c9b0074f16c62366c5c533eaacd3ff27b583 
 
 cd /repo/tools/test-generator/bin_test_gen
-sudo dune exec ./test_gen.exe --profile=release
+dune exec ./test_gen.exe --profile=release
 
 cd /repo
-sudo ocp-indent -i exercises/**/test.ml
+ocp-indent -i exercises/**/test.ml
 
 if output=$(git status --porcelain -- "exercises/**/test.ml") && [ -z "$output" ]; then
  echo "Tests are in sync."

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -9,7 +9,7 @@ RUN git checkout c23c1a7071910f235d5bc173cbadb97cd450e9fb
 RUN cd -
 
 RUN opam update
-RUN opam install dune ocamlfind      ounit qcheck react ppx_deriving ppx_let ppx_sexp_conv yojson ocp-indent calendar getopts
+RUN opam install dune ocamlfind ounit qcheck react ppx_deriving ppx_let ppx_sexp_conv yojson ocp-indent calendar getopts
 
 RUN sudo apt-get install net-tools fswatch -y
 

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -2,6 +2,22 @@ FROM ocaml/opam2:ubuntu-18.04-ocaml-4.07
 
 RUN sudo apt-get update
 RUN sudo apt-get install m4 bmake cpio -y
+
+RUN cd /home/opam/opam-repository
+RUN git pull
+RUN git checkout c23c1a7071910f235d5bc173cbadb97cd450e9fb
+RUN cd -
+
+RUN opam update
 RUN opam install dune ocamlfind core ounit qcheck react ppx_deriving yojson ounit ocp-indent calendar
 
 RUN sudo apt-get install net-tools
+
+USER root
+RUN ln -s /home/opam/.opam /root/.opam
+SHELL ["/bin/bash", "--login" , "-c"]
+ENV OPAM_SWITCH_PREFIX='/root/.opam/4.07.1'
+ENV CAML_LD_LIBRARY_PATH='/root/.opam/4.07.1/lib/stublibs:/root/.opam/4.07.1/lib/ocaml/stublibs:/root/.opam/4.07.1/lib/ocaml'
+ENV OCAML_TOPLEVEL_PATH='/root/.opam/4.07.1/lib/toplevel'
+ENV MANPATH=':/root/.opam/4.07.1/man'
+ENV PATH='/root/.opam/4.07.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,4 +1,7 @@
-FROM ocaml/opam2:alpine-3.9-ocaml-4.07
+FROM ocaml/opam2:ubuntu-18.04-ocaml-4.07
 
-RUN sudo apk add m4 linux-headers
+RUN sudo apt-get update
+RUN sudo apt-get install m4 bmake cpio -y
 RUN opam install dune ocamlfind core ounit qcheck react ppx_deriving yojson ounit ocp-indent calendar
+
+RUN sudo apt-get install net-tools

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.colorCustomizations": {}
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # assignments
 ASSIGNMENT ?= ""
-ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort)
+ASSIGNMENTS = $(shell git ls-tree --name-only HEAD -- exercises/ | awk -F/ '{print $$NF}' | sort)
 
 default: testgenerator test
 

--- a/exercises/acronym/dune
+++ b/exercises/acronym/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/all-your-base/dune
+++ b/exercises/all-your-base/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/allergies/dune
+++ b/exercises/allergies/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/anagram/dune
+++ b/exercises/anagram/dune
@@ -7,6 +7,10 @@
   (deps    (:x test.exe))
   (action  (run %{x})))
 
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
 (env
   (dev
     (flags (:standard -warn-error -A))))

--- a/exercises/atbash-cipher/dune
+++ b/exercises/atbash-cipher/dune
@@ -7,6 +7,10 @@
   (deps    (:x test.exe))
   (action  (run %{x})))
 
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
 (env
   (dev
     (flags (:standard -warn-error -A))))

--- a/exercises/beer-song/beer_song.ml
+++ b/exercises/beer-song/beer_song.ml
@@ -1,5 +1,2 @@
-let verse _ = 
-    failwith "'verse' is missing"
-
-let lyrics ~from ~until =
-    failwith "'lyrics' is missing"
+let recite ~from ~until =
+    failwith "'recite' is missing"

--- a/exercises/beer-song/beer_song.ml
+++ b/exercises/beer-song/beer_song.ml
@@ -1,2 +1,2 @@
-let recite ~from ~until =
+let recite from until =
     failwith "'recite' is missing"

--- a/exercises/beer-song/dune
+++ b/exercises/beer-song/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/binary-search/dune
+++ b/exercises/binary-search/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/bob/dune
+++ b/exercises/bob/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/bowling/dune
+++ b/exercises/bowling/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/change/dune
+++ b/exercises/change/dune
@@ -7,6 +7,10 @@
   (deps    (:x test.exe))
   (action  (run %{x})))
 
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
 (env
   (dev
     (flags (:standard -warn-error -A))))

--- a/exercises/connect/dune
+++ b/exercises/connect/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/custom-set/dune
+++ b/exercises/custom-set/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/difference-of-squares/dune
+++ b/exercises/difference-of-squares/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/dominoes/dune
+++ b/exercises/dominoes/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/etl/dune
+++ b/exercises/etl/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/forth/dune
+++ b/exercises/forth/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/grade-school/dune
+++ b/exercises/grade-school/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/hamming/dune
+++ b/exercises/hamming/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/hangman/dune
+++ b/exercises/hangman/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/hello-world/dune
+++ b/exercises/hello-world/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/hexadecimal/dune
+++ b/exercises/hexadecimal/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/leap/dune
+++ b/exercises/leap/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/list-ops/dune
+++ b/exercises/list-ops/dune
@@ -7,6 +7,10 @@
   (deps    (:x test.exe))
   (action  (run %{x})))
 
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
 (env
   (dev
     (flags (:standard -warn-error -A))))

--- a/exercises/luhn/dune
+++ b/exercises/luhn/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/matching-brackets/dune
+++ b/exercises/matching-brackets/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/meetup/dune
+++ b/exercises/meetup/dune
@@ -7,6 +7,10 @@
   (deps    (:x test.exe))
   (action  (run %{x})))
 
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
 (env
   (dev
     (flags (:standard -warn-error -A))))

--- a/exercises/minesweeper/dune
+++ b/exercises/minesweeper/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/nucleotide-count/dune
+++ b/exercises/nucleotide-count/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/palindrome-products/dune
+++ b/exercises/palindrome-products/dune
@@ -11,6 +11,10 @@
  (action
   (run %{<})))
 
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
 (env
   (dev
     (flags (:standard -warn-error -A))))

--- a/exercises/pangram/dune
+++ b/exercises/pangram/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/phone-number/dune
+++ b/exercises/phone-number/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/prime-factors/dune
+++ b/exercises/prime-factors/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/raindrops/dune
+++ b/exercises/raindrops/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/react/dune
+++ b/exercises/react/dune
@@ -7,6 +7,10 @@
   (deps    (:x test.exe))
   (action  (run %{x})))
 
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
 (env
   (dev
     (flags (:standard -warn-error -A))))

--- a/exercises/rectangles/dune
+++ b/exercises/rectangles/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/rna-transcription/dune
+++ b/exercises/rna-transcription/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/robot-name/dune
+++ b/exercises/robot-name/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/roman-numerals/dune
+++ b/exercises/roman-numerals/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/run-length-encoding/dune
+++ b/exercises/run-length-encoding/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/say/dune
+++ b/exercises/say/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/space-age/dune
+++ b/exercises/space-age/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/triangle/dune
+++ b/exercises/triangle/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/word-count/dune
+++ b/exercises/word-count/dune
@@ -6,3 +6,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/exercises/zipper/dune
+++ b/exercises/zipper/dune
@@ -7,3 +7,11 @@
   (name    runtest)
   (deps    (:x test.exe))
   (action  (run %{x})))
+
+(alias
+  (name    buildtest)
+  (deps    (:x test.exe)))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))


### PR DESCRIPTION
Compile stub files introduced via #285 against tests to ensure they stay in sync.
As per https://github.com/exercism/ocaml/pull/306#issuecomment-506813997.
Depends on #356 

* Add new `dune` alias to all exercises

```
(alias
  (name    buildtest)
  (deps    (:x test.exe)))
```

* Downgrade unused variables etc. to warnings instead of errors

```
(alias
  (name    buildtest)
  (deps    (:x test.exe)))

(env
  (dev
    (flags (:standard -warn-error -A))))
```

* Fix `beer_song` stub file by renaming `lyrics` to `recite`