### PR TITLE
test-generator: address yojson deprecations

### DIFF
--- a/tools/test-generator/lib_generator/codegen.ml
+++ b/tools/test-generator/lib_generator/codegen.ml
@@ -3,6 +3,8 @@ open Base
 open Model
 open Yojson.Basic
 
+type json = Yojson.Basic.t
+
 type edit_parameters_function = (string * json) list -> (string * string) list option
 
 type subst = Subst of string [@@deriving eq, show]

--- a/tools/test-generator/lib_generator/model.ml
+++ b/tools/test-generator/lib_generator/model.ml
@@ -3,6 +3,8 @@ open Base
 open Utils
 open Yojson.Basic
 
+type json = Yojson.Basic.t
+
 type case = {
   description: string;
   parameters: (string * json) list;

--- a/tools/test-generator/lib_generator/ocaml_special_cases.ml
+++ b/tools/test-generator/lib_generator/ocaml_special_cases.ml
@@ -4,6 +4,8 @@ open Model
 open Yojson.Basic
 open Yojson.Basic.Util
 
+type json = Yojson.Basic.t
+
 let strip_quotes s = String.drop_prefix s 1 |> Fn.flip String.drop_suffix 1
 
 let two_elt_list_to_tuple (j: json): string = match j with

--- a/tools/test-generator/lib_generator/utils.ml
+++ b/tools/test-generator/lib_generator/utils.ml
@@ -2,6 +2,8 @@ open Base
 open Yojson.Basic
 open Yojson.Basic.Util
 
+type json = Yojson.Basic.t
+
 let map2 (f: 'a -> 'b -> 'c) (r1: ('a, 'e) Result.t) (r2: ('b, 'e) Result.t): ('c, 'e) Result.t = match (r1, r2) with
   | (Error x, _) -> Error x
   | (_, Error x) -> Error x


### PR DESCRIPTION
Avoid using `Yojson.Basic.json` directly to maintain forward compatibility. Also gets rid of warnings in ci output such as: 

```
Warning 3: deprecated: Yojson.Basic.json

json types are being renamed and will be removed in the next Yojson major version. Use type t instead
```