### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
+
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
+
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
+
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
+
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
+
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
+
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
+
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
+
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/all-your-base/.meta/tests.toml
+++ b/exercises/practice/all-your-base/.meta/tests.toml
@@ -1,0 +1,73 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5ce422f9-7a4b-4f44-ad29-49c67cb32d2c]
+description = "single bit one to decimal"
+
+[0cc3fea8-bb79-46ac-a2ab-5a2c93051033]
+description = "binary to single decimal"
+
+[f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8]
+description = "single decimal to binary"
+
+[2c45cf54-6da3-4748-9733-5a3c765d925b]
+description = "binary to multiple decimal"
+
+[65ddb8b4-8899-4fcc-8618-181b2cf0002d]
+description = "decimal to binary"
+
+[8d418419-02a7-4824-8b7a-352d33c6987e]
+description = "trinary to hexadecimal"
+
+[d3901c80-8190-41b9-bd86-38d988efa956]
+description = "hexadecimal to trinary"
+
+[5d42f85e-21ad-41bd-b9be-a3e8e4258bbf]
+description = "15-bit integer"
+
+[d68788f7-66dd-43f8-a543-f15b6d233f83]
+description = "empty list"
+
+[5e27e8da-5862-4c5f-b2a9-26c0382b6be7]
+description = "single zero"
+
+[2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2]
+description = "multiple zeros"
+
+[3530cd9f-8d6d-43f5-bc6e-b30b1db9629b]
+description = "leading zeros"
+
+[a6b476a1-1901-4f2a-92c4-4d91917ae023]
+description = "input base is one"
+
+[e21a693a-7a69-450b-b393-27415c26a016]
+description = "input base is zero"
+
+[54a23be5-d99e-41cc-88e0-a650ffe5fcc2]
+description = "input base is negative"
+
+[9eccf60c-dcc9-407b-95d8-c37b8be56bb6]
+description = "negative digit"
+
+[232fa4a5-e761-4939-ba0c-ed046cd0676a]
+description = "invalid positive digit"
+
+[14238f95-45da-41dc-95ce-18f860b30ad3]
+description = "output base is one"
+
+[73dac367-da5c-4a37-95fe-c87fad0a4047]
+description = "output base is zero"
+
+[13f81f42-ff53-4e24-89d9-37603a48ebd9]
+description = "output base is negative"
+
+[0e6c895d-8a5d-4868-a345-309d094cfe8d]
+description = "both bases are negative"

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,0 +1,157 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "testing for eggs allergy -> not allergic to anything"
+
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "testing for eggs allergy -> allergic only to eggs"
+
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "testing for eggs allergy -> allergic to eggs and something else"
+
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "testing for eggs allergy -> allergic to something, but not eggs"
+
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "testing for eggs allergy -> allergic to everything"
+
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "testing for peanuts allergy -> not allergic to anything"
+
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "testing for peanuts allergy -> allergic only to peanuts"
+
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
+
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
+
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "testing for peanuts allergy -> allergic to everything"
+
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "testing for shellfish allergy -> not allergic to anything"
+
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "testing for shellfish allergy -> allergic only to shellfish"
+
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
+
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
+
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "testing for shellfish allergy -> allergic to everything"
+
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "testing for strawberries allergy -> not allergic to anything"
+
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "testing for strawberries allergy -> allergic only to strawberries"
+
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
+
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
+
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "testing for strawberries allergy -> allergic to everything"
+
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "testing for tomatoes allergy -> not allergic to anything"
+
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
+
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
+
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
+
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "testing for tomatoes allergy -> allergic to everything"
+
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "testing for chocolate allergy -> not allergic to anything"
+
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "testing for chocolate allergy -> allergic only to chocolate"
+
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
+
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
+
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "testing for chocolate allergy -> allergic to everything"
+
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "testing for pollen allergy -> not allergic to anything"
+
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "testing for pollen allergy -> allergic only to pollen"
+
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "testing for pollen allergy -> allergic to pollen and something else"
+
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "testing for pollen allergy -> allergic to something, but not pollen"
+
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "testing for pollen allergy -> allergic to everything"
+
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "testing for cats allergy -> not allergic to anything"
+
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "testing for cats allergy -> allergic only to cats"
+
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "testing for cats allergy -> allergic to cats and something else"
+
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "testing for cats allergy -> allergic to something, but not cats"
+
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "testing for cats allergy -> allergic to everything"
+
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "list when: -> no allergies"
+
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "list when: -> just eggs"
+
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "list when: -> just peanuts"
+
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "list when: -> just strawberries"
+
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "list when: -> eggs and peanuts"
+
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "list when: -> more than eggs but not peanuts"
+
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "list when: -> lots of stuff"
+
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "list when: -> everything"
+
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "list when: -> no allergen score parts"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,0 +1,56 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
+
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode -> encode yes"
+
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode -> encode no"
+
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode -> encode OMG"
+
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode -> encode spaces"
+
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode -> encode mindblowingly"
+
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode -> encode numbers"
+
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode -> encode deep thought"
+
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode -> encode all the letters"
+
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode -> decode exercism"
+
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode -> decode a sentence"
+
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode -> decode numbers"
+
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode -> decode all the letters"
+
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode -> decode with too many spaces"
+
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode -> decode with no spaces"

--- a/exercises/practice/beer-song/.meta/tests.toml
+++ b/exercises/practice/beer-song/.meta/tests.toml
@@ -1,0 +1,34 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5a02fd08-d336-4607-8006-246fe6fa9fb0]
+description = "verse -> single verse -> first generic verse"
+
+[77299ca6-545e-4217-a9cc-606b342e0187]
+description = "verse -> single verse -> last generic verse"
+
+[102cbca0-b197-40fd-b548-e99609b06428]
+description = "verse -> single verse -> verse with 2 bottles"
+
+[b8ef9fce-960e-4d85-a0c9-980a04ec1972]
+description = "verse -> single verse -> verse with 1 bottle"
+
+[c59d4076-f671-4ee3-baaa-d4966801f90d]
+description = "verse -> single verse -> verse with 0 bottles"
+
+[7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e]
+description = "lyrics -> multiple verses -> first two verses"
+
+[949868e7-67e8-43d3-9bb4-69277fe020fb]
+description = "lyrics -> multiple verses -> last three verses"
+
+[bc220626-126c-4e72-8df4-fddfc0c3e458]
+description = "lyrics -> multiple verses -> all verses"

--- a/exercises/practice/binary-search-tree/.meta/tests.toml
+++ b/exercises/practice/binary-search-tree/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e9c93a78-c536-4750-a336-94583d23fafa]
+description = "data is retained"
+
+[7a95c9e8-69f6-476a-b0c4-4170cb3f7c91]
+description = "insert data at proper node -> smaller number at left node"
+
+[22b89499-9805-4703-a159-1a6e434c1585]
+description = "insert data at proper node -> same number at left node"
+
+[2e85fdde-77b1-41ed-b6ac-26ce6b663e34]
+description = "insert data at proper node -> greater number at right node"
+
+[dd898658-40ab-41d0-965e-7f145bf66e0b]
+description = "can create complex tree"
+
+[9e0c06ef-aeca-4202-b8e4-97f1ed057d56]
+description = "can sort data -> can sort single number"
+
+[425e6d07-fceb-4681-a4f4-e46920e380bb]
+description = "can sort data -> can sort if second number is smaller than first"
+
+[bd7532cc-6988-4259-bac8-1d50140079ab]
+description = "can sort data -> can sort if second number is same as first"
+
+[b6d1b3a5-9d79-44fd-9013-c83ca92ddd36]
+description = "can sort data -> can sort if second number is greater than first"
+
+[d00ec9bd-1288-4171-b968-d44d0808c1c8]
+description = "can sort data -> can sort complex tree"

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
+description = "finds a value in an array with one element"
+
+[73469346-b0a0-4011-89bf-989e443d503d]
+description = "finds a value in the middle of an array"
+
+[327bc482-ab85-424e-a724-fb4658e66ddb]
+description = "finds a value at the beginning of an array"
+
+[f9f94b16-fe5e-472c-85ea-c513804c7d59]
+description = "finds a value at the end of an array"
+
+[f0068905-26e3-4342-856d-ad153cadb338]
+description = "finds a value in an array of odd length"
+
+[fc316b12-c8b3-4f5e-9e89-532b3389de8c]
+description = "finds a value in an array of even length"
+
+[da7db20a-354f-49f7-a6a1-650a54998aa6]
+description = "identifies that a value is not included in the array"
+
+[95d869ff-3daf-4c79-b622-6e805c675f97]
+description = "a value smaller than the array's smallest value is not found"
+
+[8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
+description = "a value larger than the array's largest value is not found"
+
+[f439a0fa-cf42-4262-8ad1-64bf41ce566a]
+description = "nothing is found in an empty array"
+
+[2c353967-b56d-40b8-acff-ce43115eed64]
+description = "nothing is found when the left and right bounds cross"

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,0 +1,85 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
+
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
+
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
+
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
+
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
+
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
+
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
+
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
+
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -1,0 +1,100 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[656ae006-25c2-438c-a549-f338e7ec7441]
+description = "should be able to score a game with all zeros"
+
+[f85dcc56-cd6b-4875-81b3-e50921e3597b]
+description = "should be able to score a game with no strikes or spares"
+
+[d1f56305-3ac2-4fe0-8645-0b37e3073e20]
+description = "a spare followed by zeros is worth ten points"
+
+[0b8c8bb7-764a-4287-801a-f9e9012f8be4]
+description = "points scored in the roll after a spare are counted twice"
+
+[4d54d502-1565-4691-84cd-f29a09c65bea]
+description = "consecutive spares each get a one roll bonus"
+
+[e5c9cf3d-abbe-4b74-ad48-34051b2b08c0]
+description = "a spare in the last frame gets a one roll bonus that is counted once"
+
+[75269642-2b34-4b72-95a4-9be28ab16902]
+description = "a strike earns ten points in a frame with a single roll"
+
+[037f978c-5d01-4e49-bdeb-9e20a2e6f9a6]
+description = "points scored in the two rolls after a strike are counted twice as a bonus"
+
+[1635e82b-14ec-4cd1-bce4-4ea14bd13a49]
+description = "consecutive strikes each get the two roll bonus"
+
+[e483e8b6-cb4b-4959-b310-e3982030d766]
+description = "a strike in the last frame gets a two roll bonus that is counted once"
+
+[9d5c87db-84bc-4e01-8e95-53350c8af1f8]
+description = "rolling a spare with the two roll bonus does not get a bonus roll"
+
+[576faac1-7cff-4029-ad72-c16bcada79b5]
+description = "strikes with the two roll bonus do not get bonus rolls"
+
+[72e24404-b6c6-46af-b188-875514c0377b]
+description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
+
+[62ee4c72-8ee8-4250-b794-234f1fec17b1]
+description = "all strikes is a perfect game"
+
+[1245216b-19c6-422c-b34b-6e4012d7459f]
+description = "rolls cannot score negative points"
+
+[5fcbd206-782c-4faa-8f3a-be5c538ba841]
+description = "a roll cannot score more than 10 points"
+
+[fb023c31-d842-422d-ad7e-79ce1db23c21]
+description = "two rolls in a frame cannot score more than 10 points"
+
+[6082d689-d677-4214-80d7-99940189381b]
+description = "bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[e9565fe6-510a-4675-ba6b-733a56767a45]
+description = "two bonus rolls after a strike in the last frame cannot score more than 10 points"
+
+[2f6acf99-448e-4282-8103-0b9c7df99c3d]
+description = "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike"
+
+[6380495a-8bc4-4cdb-a59f-5f0212dbed01]
+description = "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike"
+
+[2b2976ea-446c-47a3-9817-42777f09fe7e]
+description = "second bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[29220245-ac8d-463d-bc19-98a94cfada8a]
+description = "an unstarted game cannot be scored"
+
+[4473dc5d-1f86-486f-bf79-426a52ddc955]
+description = "an incomplete game cannot be scored"
+
+[2ccb8980-1b37-4988-b7d1-e5701c317df3]
+description = "cannot roll if game already has ten frames"
+
+[4864f09b-9df3-4b65-9924-c595ed236f1b]
+description = "bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[537f4e37-4b51-4d1c-97e2-986eb37b2ac1]
+description = "both bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[8134e8c1-4201-4197-bf9f-1431afcde4b9]
+description = "bonus roll for a spare in the last frame must be rolled before score can be calculated"
+
+[9d4a9a55-134a-4bad-bae8-3babf84bd570]
+description = "cannot roll after bonus roll for spare"
+
+[d3e02652-a799-4ae3-b53b-68582cc604be]
+description = "cannot roll after bonus rolls for strike"

--- a/exercises/practice/change/.meta/tests.toml
+++ b/exercises/practice/change/.meta/tests.toml
@@ -1,0 +1,46 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d0ebd0e1-9d27-4609-a654-df5c0ba1d83a]
+description = "change for 1 cent"
+
+[36887bea-7f92-4a9c-b0cc-c0e886b3ecc8]
+description = "single coin change"
+
+[cef21ccc-0811-4e6e-af44-f011e7eab6c6]
+description = "multiple coin change"
+
+[d60952bc-0c1a-4571-bf0c-41be72690cb3]
+description = "change with Lilliputian Coins"
+
+[408390b9-fafa-4bb9-b608-ffe6036edb6c]
+description = "change with Lower Elbonia Coins"
+
+[7421a4cb-1c48-4bf9-99c7-7f049689132f]
+description = "large target values"
+
+[f79d2e9b-0ae3-4d6a-bb58-dc978b0dba28]
+description = "possible change without unit coins available"
+
+[9a166411-d35d-4f7f-a007-6724ac266178]
+description = "another possible change without unit coins available"
+
+[bbbcc154-e9e9-4209-a4db-dd6d81ec26bb]
+description = "no coins make 0 change"
+
+[c8b81d5a-49bd-4b61-af73-8ee5383a2ce1]
+description = "error testing for change smaller than the smallest of coins"
+
+[3c43e3e4-63f9-46ac-9476-a67516e98f68]
+description = "error if no combination can add up to target"
+
+[8fe1f076-9b2d-4f44-89fe-8a6ccd63c8f3]
+description = "cannot find negative change values"

--- a/exercises/practice/connect/.meta/tests.toml
+++ b/exercises/practice/connect/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6eff0df4-3e92-478d-9b54-d3e8b354db56]
+description = "an empty board has no winner"
+
+[298b94c0-b46d-45d8-b34b-0fa2ea71f0a4]
+description = "X can win on a 1x1 board"
+
+[763bbae0-cb8f-4f28-bc21-5be16a5722dc]
+description = "O can win on a 1x1 board"
+
+[819fde60-9ae2-485e-a024-cbb8ea68751b]
+description = "only edges does not make a winner"
+
+[2c56a0d5-9528-41e5-b92b-499dfe08506c]
+description = "illegal diagonal does not make a winner"
+
+[41cce3ef-43ca-4963-970a-c05d39aa1cc1]
+description = "nobody wins crossing adjacent angles"
+
+[cd61c143-92f6-4a8d-84d9-cb2b359e226b]
+description = "X wins crossing from left to right"
+
+[73d1eda6-16ab-4460-9904-b5f5dd401d0b]
+description = "O wins crossing from top to bottom"
+
+[c3a2a550-944a-4637-8b3f-1e1bf1340a3d]
+description = "X wins using a convoluted path"
+
+[17e76fa8-f731-4db7-92ad-ed2a285d31f3]
+description = "X wins using a spiral path"

--- a/exercises/practice/custom-set/.meta/tests.toml
+++ b/exercises/practice/custom-set/.meta/tests.toml
@@ -1,0 +1,124 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[20c5f855-f83a-44a7-abdd-fe75c6cf022b]
+description = "Returns true if the set contains no elements -> sets with no elements are empty"
+
+[d506485d-5706-40db-b7d8-5ceb5acf88d2]
+description = "Returns true if the set contains no elements -> sets with elements are not empty"
+
+[759b9740-3417-44c3-8ca3-262b3c281043]
+description = "Sets can report if they contain an element -> nothing is contained in an empty set"
+
+[f83cd2d1-2a85-41bc-b6be-80adbff4be49]
+description = "Sets can report if they contain an element -> when the element is in the set"
+
+[93423fc0-44d0-4bc0-a2ac-376de8d7af34]
+description = "Sets can report if they contain an element -> when the element is not in the set"
+
+[c392923a-637b-4495-b28e-34742cd6157a]
+description = "A set is a subset if all of its elements are contained in the other set -> empty set is a subset of another empty set"
+
+[5635b113-be8c-4c6f-b9a9-23c485193917]
+description = "A set is a subset if all of its elements are contained in the other set -> empty set is a subset of non-empty set"
+
+[832eda58-6d6e-44e2-92c2-be8cf0173cee]
+description = "A set is a subset if all of its elements are contained in the other set -> non-empty set is not a subset of empty set"
+
+[c830c578-8f97-4036-b082-89feda876131]
+description = "A set is a subset if all of its elements are contained in the other set -> set is a subset of set with exact same elements"
+
+[476a4a1c-0fd1-430f-aa65-5b70cbc810c5]
+description = "A set is a subset if all of its elements are contained in the other set -> set is a subset of larger set with same elements"
+
+[d2498999-3e46-48e4-9660-1e20c3329d3d]
+description = "A set is a subset if all of its elements are contained in the other set -> set is not a subset of set that does not contain its elements"
+
+[7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc]
+description = "Sets are disjoint if they share no elements -> the empty set is disjoint with itself"
+
+[7a2b3938-64b6-4b32-901a-fe16891998a6]
+description = "Sets are disjoint if they share no elements -> empty set is disjoint with non-empty set"
+
+[589574a0-8b48-48ea-88b0-b652c5fe476f]
+description = "Sets are disjoint if they share no elements -> non-empty set is disjoint with empty set"
+
+[febeaf4f-f180-4499-91fa-59165955a523]
+description = "Sets are disjoint if they share no elements -> sets are not disjoint if they share an element"
+
+[0de20d2f-c952-468a-88c8-5e056740f020]
+description = "Sets are disjoint if they share no elements -> sets are disjoint if they share no elements"
+
+[4bd24adb-45da-4320-9ff6-38c044e9dff8]
+description = "Sets with the same elements are equal -> empty sets are equal"
+
+[f65c0a0e-6632-4b2d-b82c-b7c6da2ec224]
+description = "Sets with the same elements are equal -> empty set is not equal to non-empty set"
+
+[81e53307-7683-4b1e-a30c-7e49155fe3ca]
+description = "Sets with the same elements are equal -> non-empty set is not equal to empty set"
+
+[d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0]
+description = "Sets with the same elements are equal -> sets with the same elements are equal"
+
+[dd61bafc-6653-42cc-961a-ab071ee0ee85]
+description = "Sets with the same elements are equal -> sets with different elements are not equal"
+
+[06059caf-9bf4-425e-aaff-88966cb3ea14]
+description = "Sets with the same elements are equal -> set is not equal to larger set with same elements"
+
+[8a677c3c-a658-4d39-bb88-5b5b1a9659f4]
+description = "Unique elements can be added to a set -> add to empty set"
+
+[0903dd45-904d-4cf2-bddd-0905e1a8d125]
+description = "Unique elements can be added to a set -> add to non-empty set"
+
+[b0eb7bb7-5e5d-4733-b582-af771476cb99]
+description = "Unique elements can be added to a set -> adding an existing element does not change the set"
+
+[893d5333-33b8-4151-a3d4-8f273358208a]
+description = "Intersection returns a set of all shared elements -> intersection of two empty sets is an empty set"
+
+[d739940e-def2-41ab-a7bb-aaf60f7d782c]
+description = "Intersection returns a set of all shared elements -> intersection of an empty set and non-empty set is an empty set"
+
+[3607d9d8-c895-4d6f-ac16-a14956e0a4b7]
+description = "Intersection returns a set of all shared elements -> intersection of a non-empty set and an empty set is an empty set"
+
+[b5120abf-5b5e-41ab-aede-4de2ad85c34e]
+description = "Intersection returns a set of all shared elements -> intersection of two sets with no shared elements is an empty set"
+
+[af21ca1b-fac9-499c-81c0-92a591653d49]
+description = "Intersection returns a set of all shared elements -> intersection of two sets with shared elements is a set of the shared elements"
+
+[c5e6e2e4-50e9-4bc2-b89f-c518f015b57e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of two empty sets is an empty set"
+
+[2024cc92-5c26-44ed-aafd-e6ca27d6fcd2]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of empty set and non-empty set is an empty set"
+
+[e79edee7-08aa-4c19-9382-f6820974b43e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of a non-empty set and an empty set is the non-empty set"
+
+[c5ac673e-d707-4db5-8d69-7082c3a5437e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of two non-empty sets is a set of elements that are only in the first set"
+
+[c45aed16-5494-455a-9033-5d4c93589dc6]
+description = "Union returns a set of all elements in either set -> union of empty sets is an empty set"
+
+[9d258545-33c2-4fcb-a340-9f8aa69e7a41]
+description = "Union returns a set of all elements in either set -> union of an empty set and non-empty set is the non-empty set"
+
+[3aade50c-80c7-4db8-853d-75bac5818b83]
+description = "Union returns a set of all elements in either set -> union of a non-empty set and empty set is the non-empty set"
+
+[a00bb91f-c4b4-4844-8f77-c73e2e9df77c]
+description = "Union returns a set of all elements in either set -> union of non-empty sets contains all unique elements"

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "Square the sum of the numbers up to the given number -> square of sum 1"
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "Square the sum of the numbers up to the given number -> square of sum 5"
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "Square the sum of the numbers up to the given number -> square of sum 100"
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 1"
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 5"
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 100"
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "Subtract sum of squares from square of sums -> difference of squares 1"
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "Subtract sum of squares from square of sums -> difference of squares 5"
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "Subtract sum of squares from square of sums -> difference of squares 100"

--- a/exercises/practice/dominoes/.meta/tests.toml
+++ b/exercises/practice/dominoes/.meta/tests.toml
@@ -1,0 +1,46 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[31a673f2-5e54-49fe-bd79-1c1dae476c9c]
+description = "empty input = empty output"
+
+[4f99b933-367b-404b-8c6d-36d5923ee476]
+description = "singleton input = singleton output"
+
+[91122d10-5ec7-47cb-b759-033756375869]
+description = "singleton that can't be chained"
+
+[be8bc26b-fd3d-440b-8e9f-d698a0623be3]
+description = "three elements"
+
+[99e615c6-c059-401c-9e87-ad7af11fea5c]
+description = "can reverse dominoes"
+
+[51f0c291-5d43-40c5-b316-0429069528c9]
+description = "can't be chained"
+
+[9a75e078-a025-4c23-8c3a-238553657f39]
+description = "disconnected - simple"
+
+[0da0c7fe-d492-445d-b9ef-1f111f07a301]
+description = "disconnected - double loop"
+
+[b6087ff0-f555-4ea0-a71c-f9d707c5994a]
+description = "disconnected - single isolated"
+
+[2174fbdc-8b48-4bac-9914-8090d06ef978]
+description = "need backtrack"
+
+[167bb480-dfd1-4318-a20d-4f90adb4a09f]
+description = "separate loops"
+
+[cd061538-6046-45a7-ace9-6708fe8f6504]
+description = "nine elements"

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -1,0 +1,22 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
+description = "single letter"
+
+[60dbd000-451d-44c7-bdbb-97c73ac1f497]
+description = "single score with multiple letters"
+
+[f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
+description = "multiple scores with multiple letters"
+
+[5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
+description = "multiple scores with differing numbers of letters"

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -1,0 +1,151 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[9962203f-f00a-4a85-b404-8a8ecbcec09d]
+description = "parsing and numbers -> numbers just get pushed onto the stack"
+
+[9e69588e-a3d8-41a3-a371-ea02206c1e6e]
+description = "addition -> can add two numbers"
+
+[52336dd3-30da-4e5c-8523-bdf9a3427657]
+description = "addition -> errors if there is nothing on the stack"
+
+[06efb9a4-817a-435e-b509-06166993c1b8]
+description = "addition -> errors if there is only one value on the stack"
+
+[09687c99-7bbc-44af-8526-e402f997ccbf]
+description = "subtraction -> can subtract two numbers"
+
+[5d63eee2-1f7d-4538-b475-e27682ab8032]
+description = "subtraction -> errors if there is nothing on the stack"
+
+[b3cee1b2-9159-418a-b00d-a1bb3765c23b]
+description = "subtraction -> errors if there is only one value on the stack"
+
+[5df0ceb5-922e-401f-974d-8287427dbf21]
+description = "multiplication -> can multiply two numbers"
+
+[9e004339-15ac-4063-8ec1-5720f4e75046]
+description = "multiplication -> errors if there is nothing on the stack"
+
+[8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
+description = "multiplication -> errors if there is only one value on the stack"
+
+[e74c2204-b057-4cff-9aa9-31c7c97a93f5]
+description = "division -> can divide two numbers"
+
+[54f6711c-4b14-4bb0-98ad-d974a22c4620]
+description = "division -> performs integer division"
+
+[a5df3219-29b4-4d2f-b427-81f82f42a3f1]
+description = "division -> errors if dividing by zero"
+
+[1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
+description = "division -> errors if there is nothing on the stack"
+
+[d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
+description = "division -> errors if there is only one value on the stack"
+
+[ee28d729-6692-4a30-b9be-0d830c52a68c]
+description = "combined arithmetic -> addition and subtraction"
+
+[40b197da-fa4b-4aca-a50b-f000d19422c1]
+description = "combined arithmetic -> multiplication and division"
+
+[c5758235-6eef-4bf6-ab62-c878e50b9957]
+description = "dup -> copies a value on the stack"
+
+[f6889006-5a40-41e7-beb3-43b09e5a22f4]
+description = "dup -> copies the top value on the stack"
+
+[40b7569c-8401-4bd4-a30d-9adf70d11bc4]
+description = "dup -> errors if there is nothing on the stack"
+
+[1971da68-1df2-4569-927a-72bf5bb7263c]
+description = "drop -> removes the top value on the stack if it is the only one"
+
+[8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
+description = "drop -> removes the top value on the stack if it is not the only one"
+
+[6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
+description = "drop -> errors if there is nothing on the stack"
+
+[3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
+description = "swap -> swaps the top two values on the stack if they are the only ones"
+
+[8ce869d5-a503-44e4-ab55-1da36816ff1c]
+description = "swap -> swaps the top two values on the stack if they are not the only ones"
+
+[74ba5b2a-b028-4759-9176-c5c0e7b2b154]
+description = "swap -> errors if there is nothing on the stack"
+
+[dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
+description = "swap -> errors if there is only one value on the stack"
+
+[a2654074-ba68-4f93-b014-6b12693a8b50]
+description = "over -> copies the second element if there are only two"
+
+[c5b51097-741a-4da7-8736-5c93fa856339]
+description = "over -> copies the second element if there are more than two"
+
+[6e1703a6-5963-4a03-abba-02e77e3181fd]
+description = "over -> errors if there is nothing on the stack"
+
+[ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
+description = "over -> errors if there is only one value on the stack"
+
+[ed45cbbf-4dbf-4901-825b-54b20dbee53b]
+description = "user-defined words -> can consist of built-in words"
+
+[2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
+description = "user-defined words -> execute in the right order"
+
+[9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
+description = "user-defined words -> can override other user-defined words"
+
+[669db3f3-5bd6-4be0-83d1-618cd6e4984b]
+description = "user-defined words -> can override built-in words"
+
+[588de2f0-c56e-4c68-be0b-0bb1e603c500]
+description = "user-defined words -> can override built-in operators"
+
+[ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
+description = "user-defined words -> can use different words with the same name"
+
+[53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
+description = "user-defined words -> can define word that uses word with the same name"
+
+[35958cee-a976-4a0f-9378-f678518fa322]
+description = "user-defined words -> cannot redefine non-negative numbers"
+
+[df5b2815-3843-4f55-b16c-c3ed507292a7]
+description = "user-defined words -> cannot redefine negative numbers"
+
+[5180f261-89dd-491e-b230-62737e09806f]
+description = "user-defined words -> errors if executing a non-existent word"
+
+[7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
+description = "case-insensitivity -> DUP is case-insensitive"
+
+[339ed30b-f5b4-47ff-ab1c-67591a9cd336]
+description = "case-insensitivity -> DROP is case-insensitive"
+
+[ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
+description = "case-insensitivity -> SWAP is case-insensitive"
+
+[acdc3a49-14c8-4cc2-945d-11edee6408fa]
+description = "case-insensitivity -> OVER is case-insensitive"
+
+[5934454f-a24f-4efc-9fdd-5794e5f0c23c]
+description = "case-insensitivity -> user-defined words are case-insensitive"
+
+[037d4299-195f-4be7-a46d-f07ca6280a06]
+description = "case-insensitivity -> definitions are case-insensitive"

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -1,0 +1,34 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6d0a30e4-1b4e-472e-8e20-c41702125667]
+description = "Adding a student adds them to the sorted roster"
+
+[c125dab7-2a53-492f-a99a-56ad511940d8]
+description = "A student can't be in two different grades"
+
+[233be705-dd58-4968-889d-fb3c7954c9cc]
+description = "Adding more students adds them to the sorted roster"
+
+[75a51579-d1d7-407c-a2f8-2166e984e8ab]
+description = "Adding students to different grades adds them to the same sorted roster"
+
+[a3f0fb58-f240-4723-8ddc-e644666b85cc]
+description = "Roster returns an empty list if there are no students enrolled"
+
+[180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
+description = "Student names with grades are displayed in the same sorted roster"
+
+[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
+description = "Grade returns the students in that grade in alphabetical order"
+
+[5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
+description = "Grade returns an empty list if there are no students in that grade"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,13 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,0 +1,100 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[485b9452-bf94-40f7-a3db-c3cf4850066a]
+description = "append entries to a list and return the new list -> empty lists"
+
+[2c894696-b609-4569-b149-8672134d340a]
+description = "append entries to a list and return the new list -> list to empty list"
+
+[e842efed-3bf6-4295-b371-4d67a4fdf19c]
+description = "append entries to a list and return the new list -> empty list to list"
+
+[71dcf5eb-73ae-4a0e-b744-a52ee387922f]
+description = "append entries to a list and return the new list -> non-empty lists"
+
+[28444355-201b-4af2-a2f6-5550227bde21]
+description = "concatenate a list of lists -> empty list"
+
+[331451c1-9573-42a1-9869-2d06e3b389a9]
+description = "concatenate a list of lists -> list of lists"
+
+[d6ecd72c-197f-40c3-89a4-aa1f45827e09]
+description = "concatenate a list of lists -> list of nested lists"
+
+[0524fba8-3e0f-4531-ad2b-f7a43da86a16]
+description = "filter list returning only values that satisfy the filter function -> empty list"
+
+[88494bd5-f520-4edb-8631-88e415b62d24]
+description = "filter list returning only values that satisfy the filter function -> non-empty list"
+
+[1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
+description = "returns the length of a list -> empty list"
+
+[d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
+description = "returns the length of a list -> non-empty list"
+
+[c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
+
+[11e71a95-e78b-4909-b8e4-60cdcaec0e91]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> non-empty list"
+
+[613b20b7-1873-4070-a3a6-70ae5f50d7cc]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+
+[e56df3eb-9405-416a-b13a-aabb4c3b5194]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+
+[d2cf5644-aee1-4dfc-9b88-06896676fe27]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+
+[36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+reimplements = "613b20b7-1873-4070-a3a6-70ae5f50d7cc"
+
+[7a626a3c-03ec-42bc-9840-53f280e13067]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
+
+[d7fcad99-e88e-40e1-a539-4c519681f390]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
+
+[aeb576b9-118e-4a57-a451-db49fac20fdc]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+
+[c4b64e58-313e-4c47-9c68-7764964efb8e]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+
+[be396a53-c074-4db3-8dd6-f7ed003cce7c]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+
+[17214edb-20ba-42fc-bda8-000a5ab525b0]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+reimplements = "aeb576b9-118e-4a57-a451-db49fac20fdc"
+
+[e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
+
+[8066003b-f2ff-437e-9103-66e6df474844]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
+
+[94231515-050e-4841-943d-d4488ab4ee30]
+description = "reverse the elements of the list -> empty list"
+
+[fcc03d1e-42e0-4712-b689-d54ad761f360]
+description = "reverse the elements of the list -> non-empty list"
+
+[40872990-b5b8-4cb8-9085-d91fc0d05d26]
+description = "reverse the elements of the list -> list of lists is not flattened"

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[792a7082-feb7-48c7-b88b-bbfec160865e]
+description = "single digit strings can not be valid"
+
+[698a7924-64d4-4d89-8daa-32e1aadc271e]
+description = "a single zero is invalid"
+
+[73c2f62b-9b10-4c9f-9a04-83cee7367965]
+description = "a simple valid SIN that remains valid if reversed"
+
+[9369092e-b095-439f-948d-498bd076be11]
+description = "a simple valid SIN that becomes invalid if reversed"
+
+[8f9f2350-1faf-4008-ba84-85cbb93ffeca]
+description = "a valid Canadian SIN"
+
+[1cdcf269-6560-44fc-91f6-5819a7548737]
+description = "invalid Canadian SIN"
+
+[656c48c1-34e8-4e60-9a5a-aad8a367810a]
+description = "invalid credit card"
+
+[20e67fad-2121-43ed-99a8-14b5b856adb9]
+description = "invalid long number with an even remainder"
+
+[ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
+description = "valid number with an even number of digits"
+
+[ef081c06-a41f-4761-8492-385e13c8202d]
+description = "valid number with an odd number of spaces"
+
+[bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
+description = "valid strings with a non-digit added at the end become invalid"
+
+[2177e225-9ce7-40f6-b55d-fa420e62938e]
+description = "valid strings with punctuation included become invalid"
+
+[ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
+description = "valid strings with symbols included become invalid"
+
+[08195c5e-ce7f-422c-a5eb-3e45fece68ba]
+description = "single zero with space is invalid"
+
+[12e63a3c-f866-4a79-8c14-b359fc386091]
+description = "more than a single zero is valid"
+
+[ab56fa80-5de8-4735-8a4a-14dae588663e]
+description = "input digit 9 is correctly converted to output digit 9"
+
+[39a06a5a-5bad-4e0f-b215-b042d46209b1]
+description = "using ascii value for non-doubled non-digit isn't allowed"
+
+[f94cf191-a62f-4868-bc72-7253114aa157]
+description = "using ascii value for doubled non-digit isn't allowed"
+
+[8b72ad26-c8be-49a2-b99c-bcc3bf631b33]
+description = "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed"

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[81ec11da-38dd-442a-bcf9-3de7754609a5]
+description = "paired square brackets"
+
+[287f0167-ac60-4b64-8452-a0aa8f4e5238]
+description = "empty string"
+
+[6c3615a3-df01-4130-a731-8ef5f5d78dac]
+description = "unpaired brackets"
+
+[9d414171-9b98-4cac-a4e5-941039a97a77]
+description = "wrong ordered brackets"
+
+[f0f97c94-a149-4736-bc61-f2c5148ffb85]
+description = "wrong closing bracket"
+
+[754468e0-4696-4582-a30e-534d47d69756]
+description = "paired with whitespace"
+
+[ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
+description = "partially paired brackets"
+
+[3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
+description = "simple nested brackets"
+
+[2d137f2c-a19e-4993-9830-83967a2d4726]
+description = "several paired brackets"
+
+[2e1f7b56-c137-4c92-9781-958638885a44]
+description = "paired and nested brackets"
+
+[84f6233b-e0f7-4077-8966-8085d295c19b]
+description = "unopened closing brackets"
+
+[9b18c67d-7595-4982-b2c5-4cb949745d49]
+description = "unpaired and nested brackets"
+
+[a0205e34-c2ac-49e6-a88a-899508d7d68e]
+description = "paired and wrong nested brackets"
+
+[ef47c21b-bcfd-4998-844c-7ad5daad90a8]
+description = "paired and incomplete brackets"
+
+[a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
+description = "too many closing brackets"
+
+[99255f93-261b-4435-a352-02bdecc9bdf2]
+description = "math expression"
+
+[8e357d79-f302-469a-8515-2561877256a1]
+description = "complex latex expression"

--- a/exercises/practice/meetup/.meta/tests.toml
+++ b/exercises/practice/meetup/.meta/tests.toml
@@ -1,0 +1,295 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8]
+description = "monteenth of May 2013"
+
+[f78373d1-cd53-4a7f-9d37-e15bf8a456b4]
+description = "monteenth of August 2013"
+
+[8c78bea7-a116-425b-9c6b-c9898266d92a]
+description = "monteenth of September 2013"
+
+[cfef881b-9dc9-4d0b-8de4-82d0f39fc271]
+description = "tuesteenth of March 2013"
+
+[69048961-3b00-41f9-97ee-eb6d83a8e92b]
+description = "tuesteenth of April 2013"
+
+[d30bade8-3622-466a-b7be-587414e0caa6]
+description = "tuesteenth of August 2013"
+
+[8db4b58b-92f3-4687-867b-82ee1a04f851]
+description = "wednesteenth of January 2013"
+
+[6c27a2a2-28f8-487f-ae81-35d08c4664f7]
+description = "wednesteenth of February 2013"
+
+[008a8674-1958-45b5-b8e6-c2c9960d973a]
+description = "wednesteenth of June 2013"
+
+[e4abd5e3-57cb-4091-8420-d97e955c0dbd]
+description = "thursteenth of May 2013"
+
+[85da0b0f-eace-4297-a6dd-63588d5055b4]
+description = "thursteenth of June 2013"
+
+[ecf64f9b-8413-489b-bf6e-128045f70bcc]
+description = "thursteenth of September 2013"
+
+[ac4e180c-7d0a-4d3d-b05f-f564ebb584ca]
+description = "friteenth of April 2013"
+
+[b79101c7-83ad-4f8f-8ec8-591683296315]
+description = "friteenth of August 2013"
+
+[6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8]
+description = "friteenth of September 2013"
+
+[dfae03ed-9610-47de-a632-655ab01e1e7c]
+description = "saturteenth of February 2013"
+
+[ec02e3e1-fc72-4a3c-872f-a53fa8ab358e]
+description = "saturteenth of April 2013"
+
+[d983094b-7259-4195-b84e-5d09578c89d9]
+description = "saturteenth of October 2013"
+
+[d84a2a2e-f745-443a-9368-30051be60c2e]
+description = "sunteenth of May 2013"
+
+[0e64bc53-92a3-4f61-85b2-0b7168c7ce5a]
+description = "sunteenth of June 2013"
+
+[de87652c-185e-4854-b3ae-04cf6150eead]
+description = "sunteenth of October 2013"
+
+[2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411]
+description = "first Monday of March 2013"
+
+[a6168c7c-ed95-4bb3-8f92-c72575fc64b0]
+description = "first Monday of April 2013"
+
+[1bfc620f-1c54-4bbd-931f-4a1cd1036c20]
+description = "first Tuesday of May 2013"
+
+[12959c10-7362-4ca0-a048-50cf1c06e3e2]
+description = "first Tuesday of June 2013"
+
+[1033dc66-8d0b-48a1-90cb-270703d59d1d]
+description = "first Wednesday of July 2013"
+
+[b89185b9-2f32-46f4-a602-de20b09058f6]
+description = "first Wednesday of August 2013"
+
+[53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5]
+description = "first Thursday of September 2013"
+
+[b420a7e3-a94c-4226-870a-9eb3a92647f0]
+description = "first Thursday of October 2013"
+
+[61df3270-28b4-4713-bee2-566fa27302ca]
+description = "first Friday of November 2013"
+
+[cad33d4d-595c-412f-85cf-3874c6e07abf]
+description = "first Friday of December 2013"
+
+[a2869b52-5bba-44f0-a863-07bd1f67eadb]
+description = "first Saturday of January 2013"
+
+[3585315a-d0db-4ea1-822e-0f22e2a645f5]
+description = "first Saturday of February 2013"
+
+[c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1]
+description = "first Sunday of March 2013"
+
+[1513328b-df53-4714-8677-df68c4f9366c]
+description = "first Sunday of April 2013"
+
+[49e083af-47ec-4018-b807-62ef411efed7]
+description = "second Monday of March 2013"
+
+[6cb79a73-38fe-4475-9101-9eec36cf79e5]
+description = "second Monday of April 2013"
+
+[4c39b594-af7e-4445-aa03-bf4f8effd9a1]
+description = "second Tuesday of May 2013"
+
+[41b32c34-2e39-40e3-b790-93539aaeb6dd]
+description = "second Tuesday of June 2013"
+
+[90a160c5-b5d9-4831-927f-63a78b17843d]
+description = "second Wednesday of July 2013"
+
+[23b98ce7-8dd5-41a1-9310-ef27209741cb]
+description = "second Wednesday of August 2013"
+
+[447f1960-27ca-4729-bc3f-f36043f43ed0]
+description = "second Thursday of September 2013"
+
+[c9aa2687-300c-4e79-86ca-077849a81bde]
+description = "second Thursday of October 2013"
+
+[a7e11ef3-6625-4134-acda-3e7195421c09]
+description = "second Friday of November 2013"
+
+[8b420e5f-9290-4106-b5ae-022f3e2a3e41]
+description = "second Friday of December 2013"
+
+[80631afc-fc11-4546-8b5f-c12aaeb72b4f]
+description = "second Saturday of January 2013"
+
+[e34d43ac-f470-44c2-aa5f-e97b78ecaf83]
+description = "second Saturday of February 2013"
+
+[a57d59fd-1023-47ad-b0df-a6feb21b44fc]
+description = "second Sunday of March 2013"
+
+[a829a8b0-abdd-4ad1-b66c-5560d843c91a]
+description = "second Sunday of April 2013"
+
+[501a8a77-6038-4fc0-b74c-33634906c29d]
+description = "third Monday of March 2013"
+
+[49e4516e-cf32-4a58-8bbc-494b7e851c92]
+description = "third Monday of April 2013"
+
+[4db61095-f7c7-493c-85f1-9996ad3012c7]
+description = "third Tuesday of May 2013"
+
+[714fc2e3-58d0-4b91-90fd-61eefd2892c0]
+description = "third Tuesday of June 2013"
+
+[b08a051a-2c80-445b-9b0e-524171a166d1]
+description = "third Wednesday of July 2013"
+
+[80bb9eff-3905-4c61-8dc9-bb03016d8ff8]
+description = "third Wednesday of August 2013"
+
+[fa52a299-f77f-4784-b290-ba9189fbd9c9]
+description = "third Thursday of September 2013"
+
+[f74b1bc6-cc5c-4bf1-ba69-c554a969eb38]
+description = "third Thursday of October 2013"
+
+[8900f3b0-801a-466b-a866-f42d64667abd]
+description = "third Friday of November 2013"
+
+[538ac405-a091-4314-9ccd-920c4e38e85e]
+description = "third Friday of December 2013"
+
+[244db35c-2716-4fa0-88ce-afd58e5cf910]
+description = "third Saturday of January 2013"
+
+[dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e]
+description = "third Saturday of February 2013"
+
+[be71dcc6-00d2-4b53-a369-cbfae55b312f]
+description = "third Sunday of March 2013"
+
+[b7d2da84-4290-4ee6-a618-ee124ae78be7]
+description = "third Sunday of April 2013"
+
+[4276dc06-a1bd-4fc2-b6c2-625fee90bc88]
+description = "fourth Monday of March 2013"
+
+[ddbd7976-2deb-4250-8a38-925ac1a8e9a2]
+description = "fourth Monday of April 2013"
+
+[eb714ef4-1656-47cc-913c-844dba4ebddd]
+description = "fourth Tuesday of May 2013"
+
+[16648435-7937-4d2d-b118-c3e38fd084bd]
+description = "fourth Tuesday of June 2013"
+
+[de062bdc-9484-437a-a8c5-5253c6f6785a]
+description = "fourth Wednesday of July 2013"
+
+[c2ce6821-169c-4832-8d37-690ef5d9514a]
+description = "fourth Wednesday of August 2013"
+
+[d462c631-2894-4391-a8e3-dbb98b7a7303]
+description = "fourth Thursday of September 2013"
+
+[9ff1f7b6-1b72-427d-9ee9-82b5bb08b835]
+description = "fourth Thursday of October 2013"
+
+[83bae8ba-1c49-49bc-b632-b7c7e1d7e35f]
+description = "fourth Friday of November 2013"
+
+[de752d2a-a95e-48d2-835b-93363dac3710]
+description = "fourth Friday of December 2013"
+
+[eedd90ad-d581-45db-8312-4c6dcf9cf560]
+description = "fourth Saturday of January 2013"
+
+[669fedcd-912e-48c7-a0a1-228b34af91d0]
+description = "fourth Saturday of February 2013"
+
+[648e3849-ea49-44a5-a8a3-9f2a43b3bf1b]
+description = "fourth Sunday of March 2013"
+
+[f81321b3-99ab-4db6-9267-69c5da5a7823]
+description = "fourth Sunday of April 2013"
+
+[1af5e51f-5488-4548-aee8-11d7d4a730dc]
+description = "last Monday of March 2013"
+
+[f29999f2-235e-4ec7-9dab-26f137146526]
+description = "last Monday of April 2013"
+
+[31b097a0-508e-48ac-bf8a-f63cdcf6dc41]
+description = "last Tuesday of May 2013"
+
+[8c022150-0bb5-4a1f-80f9-88b2e2abcba4]
+description = "last Tuesday of June 2013"
+
+[0e762194-672a-4bdf-8a37-1e59fdacef12]
+description = "last Wednesday of July 2013"
+
+[5016386a-f24e-4bd7-b439-95358f491b66]
+description = "last Wednesday of August 2013"
+
+[12ead1a5-cdf9-4192-9a56-2229e93dd149]
+description = "last Thursday of September 2013"
+
+[7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7]
+description = "last Thursday of October 2013"
+
+[e47a739e-b979-460d-9c8a-75c35ca2290b]
+description = "last Friday of November 2013"
+
+[5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec]
+description = "last Friday of December 2013"
+
+[61e54cba-76f3-4772-a2b1-bf443fda2137]
+description = "last Saturday of January 2013"
+
+[8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f]
+description = "last Saturday of February 2013"
+
+[0b63e682-f429-4d19-9809-4a45bd0242dc]
+description = "last Sunday of March 2013"
+
+[5232307e-d3e3-4afc-8ba6-4084ad987c00]
+description = "last Sunday of April 2013"
+
+[0bbd48e8-9773-4e81-8e71-b9a51711e3c5]
+description = "last Wednesday of February 2012"
+
+[fe0936de-7eee-4a48-88dd-66c07ab1fefc]
+description = "last Wednesday of December 2014"
+
+[2ccf2488-aafc-4671-a24e-2b6effe1b0e2]
+description = "last Sunday of February 2015"
+
+[00c3ce9f-cf36-4b70-90d8-92b32be6830e]
+description = "first Friday of December 2012"

--- a/exercises/practice/minesweeper/.meta/tests.toml
+++ b/exercises/practice/minesweeper/.meta/tests.toml
@@ -1,0 +1,46 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[0c5ec4bd-dea7-4138-8651-1203e1cb9f44]
+description = "no rows"
+
+[650ac4c0-ad6b-4b41-acde-e4ea5852c3b8]
+description = "no columns"
+
+[6fbf8f6d-a03b-42c9-9a58-b489e9235478]
+description = "no mines"
+
+[61aff1c4-fb31-4078-acad-cd5f1e635655]
+description = "minefield with only mines"
+
+[84167147-c504-4896-85d7-246b01dea7c5]
+description = "mine surrounded by spaces"
+
+[cb878f35-43e3-4c9d-93d9-139012cccc4a]
+description = "space surrounded by mines"
+
+[7037f483-ddb4-4b35-b005-0d0f4ef4606f]
+description = "horizontal line"
+
+[e359820f-bb8b-4eda-8762-47b64dba30a6]
+description = "horizontal line, mines at edges"
+
+[c5198b50-804f-47e9-ae02-c3b42f7ce3ab]
+description = "vertical line"
+
+[0c79a64d-703d-4660-9e90-5adfa5408939]
+description = "vertical line, mines at edges"
+
+[4b098563-b7f3-401c-97c6-79dd1b708f34]
+description = "cross"
+
+[04a260f1-b40a-4e89-839e-8dd8525abe0e]
+description = "large minefield"

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[3e5c30a8-87e2-4845-a815-a49671ade970]
+description = "empty strand"
+
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
+
+[eca0d565-ed8c-43e7-9033-6cefbf5115b5]
+description = "strand with repeated nucleotide"
+
+[40a45eac-c83f-4740-901a-20b22d15a39f]
+description = "strand with multiple nucleotides"
+
+[b4c47851-ee9e-4b0a-be70-a86e343bd851]
+description = "strand with invalid nucleotides"

--- a/exercises/practice/palindrome-products/.meta/tests.toml
+++ b/exercises/practice/palindrome-products/.meta/tests.toml
@@ -1,0 +1,46 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5cff78fe-cf02-459d-85c2-ce584679f887]
+description = "finds the smallest palindrome from single digit factors"
+
+[0853f82c-5fc4-44ae-be38-fadb2cced92d]
+description = "finds the largest palindrome from single digit factors"
+
+[66c3b496-bdec-4103-9129-3fcb5a9063e1]
+description = "find the smallest palindrome from double digit factors"
+
+[a10682ae-530a-4e56-b89d-69664feafe53]
+description = "find the largest palindrome from double digit factors"
+
+[cecb5a35-46d1-4666-9719-fa2c3af7499d]
+description = "find smallest palindrome from triple digit factors"
+
+[edab43e1-c35f-4ea3-8c55-2f31dddd92e5]
+description = "find the largest palindrome from triple digit factors"
+
+[4f802b5a-9d74-4026-a70f-b53ff9234e4e]
+description = "find smallest palindrome from four digit factors"
+
+[787525e0-a5f9-40f3-8cb2-23b52cf5d0be]
+description = "find the largest palindrome from four digit factors"
+
+[58fb1d63-fddb-4409-ab84-a7a8e58d9ea0]
+description = "empty result for smallest if no palindrome in the range"
+
+[9de9e9da-f1d9-49a5-8bfc-3d322efbdd02]
+description = "empty result for largest if no palindrome in the range"
+
+[12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a]
+description = "error result for smallest if min is more than max"
+
+[eeeb5bff-3f47-4b1e-892f-05829277bd74]
+description = "error result for largest if min is more than max"

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
+
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
+
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
+
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
+
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
+
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
+
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
+
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
+
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
+
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[79666dce-e0f1-46de-95a1-563802913c35]
+description = "cleans the number"
+
+[c360451f-549f-43e4-8aba-fdf6cb0bf83f]
+description = "cleans numbers with dots"
+
+[08f94c34-9a37-46a2-a123-2a8e9727395d]
+description = "cleans numbers with multiple spaces"
+
+[598d8432-0659-4019-a78b-1c6a73691d21]
+description = "invalid when 9 digits"
+
+[57061c72-07b5-431f-9766-d97da7c4399d]
+description = "invalid when 11 digits does not start with a 1"
+
+[9962cbf3-97bb-4118-ba9b-38ff49c64430]
+description = "valid when 11 digits and starting with 1"
+
+[fa724fbf-054c-4d91-95da-f65ab5b6dbca]
+description = "valid when 11 digits and starting with 1 even with punctuation"
+
+[c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
+description = "invalid when more than 11 digits"
+
+[63f38f37-53f6-4a5f-bd86-e9b404f10a60]
+description = "invalid with letters"
+
+[4bd97d90-52fd-45d3-b0db-06ab95b1244e]
+description = "invalid with punctuations"
+
+[d77d07f8-873c-4b17-8978-5f66139bf7d7]
+description = "invalid if area code starts with 0"
+
+[c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
+description = "invalid if area code starts with 1"
+
+[4d622293-6976-413d-b8bf-dd8a94d4e2ac]
+description = "invalid if exchange code starts with 0"
+
+[4cef57b4-7d8e-43aa-8328-1e1b89001262]
+description = "invalid if exchange code starts with 1"
+
+[9925b09c-1a0d-4960-a197-5d163cbe308c]
+description = "invalid if area code starts with 0 on valid 11-digit number"
+
+[3f809d37-40f3-44b5-ad90-535838b1a816]
+description = "invalid if area code starts with 1 on valid 11-digit number"
+
+[e08e5532-d621-40d4-b0cc-96c159276b65]
+description = "invalid if exchange code starts with 0 on valid 11-digit number"
+
+[57b32f3d-696a-455c-8bf1-137b6d171cdf]
+description = "invalid if exchange code starts with 1 on valid 11-digit number"

--- a/exercises/practice/prime-factors/.meta/tests.toml
+++ b/exercises/practice/prime-factors/.meta/tests.toml
@@ -1,0 +1,46 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[924fc966-a8f5-4288-82f2-6b9224819ccd]
+description = "no factors"
+
+[17e30670-b105-4305-af53-ddde182cb6ad]
+description = "prime number"
+
+[238d57c8-4c12-42ef-af34-ae4929f94789]
+description = "another prime number"
+
+[f59b8350-a180-495a-8fb1-1712fbee1158]
+description = "square of a prime"
+
+[756949d3-3158-4e3d-91f2-c4f9f043ee70]
+description = "product of first prime"
+
+[bc8c113f-9580-4516-8669-c5fc29512ceb]
+description = "cube of a prime"
+
+[7d6a3300-a4cb-4065-bd33-0ced1de6cb44]
+description = "product of second prime"
+
+[073ac0b2-c915-4362-929d-fc45f7b9a9e4]
+description = "product of third prime"
+
+[6e0e4912-7fb6-47f3-a9ad-dbcd79340c75]
+description = "product of first and second prime"
+
+[00485cd3-a3fe-4fbe-a64a-a4308fc1f870]
+description = "product of primes and non-primes"
+
+[02251d54-3ca1-4a9b-85e1-b38f4b0ccb91]
+description = "product of primes"
+
+[070cf8dc-e202-4285-aa37-8d775c9cd473]
+description = "factors include a large prime"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/react/.meta/tests.toml
+++ b/exercises/practice/react/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c51ee736-d001-4f30-88d1-0c8e8b43cd07]
+description = "input cells have a value"
+
+[dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851]
+description = "an input cell's value can be set"
+
+[5854b975-f545-4f93-8968-cc324cde746e]
+description = "compute cells calculate initial value"
+
+[25795a3d-b86c-4e91-abe7-1c340e71560c]
+description = "compute cells take inputs in the right order"
+
+[c62689bf-7be5-41bb-b9f8-65178ef3e8ba]
+description = "compute cells update value when dependencies are changed"
+
+[5ff36b09-0a88-48d4-b7f8-69dcf3feea40]
+description = "compute cells can depend on other compute cells"
+
+[abe33eaf-68ad-42a5-b728-05519ca88d2d]
+description = "compute cells fire callbacks"
+
+[9e5cb3a4-78e5-4290-80f8-a78612c52db2]
+description = "callback cells only fire on change"
+
+[ada17cb6-7332-448a-b934-e3d7495c13d3]
+description = "callbacks do not report already reported values"
+
+[ac271900-ea5c-461c-9add-eeebcb8c03e5]
+description = "callbacks can fire from multiple cells"
+
+[95a82dcc-8280-4de3-a4cd-4f19a84e3d6f]
+description = "callbacks can be added and removed"
+
+[f2a7b445-f783-4e0e-8393-469ab4915f2a]
+description = "removing a callback multiple times doesn't interfere with other callbacks"
+
+[daf6feca-09e0-4ce5-801d-770ddfe1c268]
+description = "callbacks should only be called once even if multiple dependencies change"
+
+[9a5b159f-b7aa-4729-807e-f1c38a46d377]
+description = "callbacks should not be called if dependencies change but output value doesn't change"

--- a/exercises/practice/rectangles/.meta/tests.toml
+++ b/exercises/practice/rectangles/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[485b7bab-4150-40aa-a8db-73013427d08c]
+description = "no rows"
+
+[076929ed-27e8-45dc-b14b-08279944dc49]
+description = "no columns"
+
+[0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa]
+description = "no rectangles"
+
+[a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd]
+description = "one rectangle"
+
+[ced06550-83da-4d23-98b7-d24152e0db93]
+description = "two rectangles without shared parts"
+
+[5942d69a-a07c-41c8-8b93-2d13877c706a]
+description = "five rectangles with shared parts"
+
+[82d70be4-ab37-4bf2-a433-e33778d3bbf1]
+description = "rectangle of height 1 is counted"
+
+[57f1bc0e-2782-401e-ab12-7c01d8bfc2e0]
+description = "rectangle of width 1 is counted"
+
+[ef0bb65c-bd80-4561-9535-efc4067054f9]
+description = "1x1 square is counted"
+
+[e1e1d444-e926-4d30-9bf3-7d8ec9a9e330]
+description = "only complete rectangles are counted"
+
+[ca021a84-1281-4a56-9b9b-af14113933a4]
+description = "rectangles can be of different sizes"
+
+[51f689a7-ef3f-41ae-aa2f-5ea09ad897ff]
+description = "corner is required for a rectangle to be complete"
+
+[d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66]
+description = "large input with many rectangles"

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is I"
+
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is II"
+
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is III"
+
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4 is IV"
+
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is V"
+
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6 is VI"
+
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9 is IX"
+
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "27 is XXVII"
+
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is XLVIII"
+
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is XLIX"
+
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "59 is LIX"
+
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "93 is XCIII"
+
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "141 is CXLI"
+
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "163 is CLXIII"
+
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "402 is CDII"
+
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "575 is DLXXV"
+
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "911 is CMXI"
+
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1024 is MXXIV"
+
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"

--- a/exercises/practice/run-length-encoding/.meta/tests.toml
+++ b/exercises/practice/run-length-encoding/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[ad53b61b-6ffc-422f-81a6-61f7df92a231]
+description = "run-length encode a string -> empty string"
+
+[52012823-b7e6-4277-893c-5b96d42f82de]
+description = "run-length encode a string -> single characters only are encoded without count"
+
+[b7868492-7e3a-415f-8da3-d88f51f80409]
+description = "run-length encode a string -> string with no single characters"
+
+[859b822b-6e9f-44d6-9c46-6091ee6ae358]
+description = "run-length encode a string -> single characters mixed with repeated characters"
+
+[1b34de62-e152-47be-bc88-469746df63b3]
+description = "run-length encode a string -> multiple whitespace mixed in string"
+
+[abf176e2-3fbd-40ad-bb2f-2dd6d4df721a]
+description = "run-length encode a string -> lowercase characters"
+
+[7ec5c390-f03c-4acf-ac29-5f65861cdeb5]
+description = "run-length decode a string -> empty string"
+
+[ad23f455-1ac2-4b0e-87d0-b85b10696098]
+description = "run-length decode a string -> single characters only"
+
+[21e37583-5a20-4a0e-826c-3dee2c375f54]
+description = "run-length decode a string -> string with no single characters"
+
+[1389ad09-c3a8-4813-9324-99363fba429c]
+description = "run-length decode a string -> single characters with repeated characters"
+
+[3f8e3c51-6aca-4670-b86c-a213bf4706b0]
+description = "run-length decode a string -> multiple whitespace mixed in string"
+
+[29f721de-9aad-435f-ba37-7662df4fb551]
+description = "run-length decode a string -> lowercase string"
+
+[2a762efd-8695-4e04-b0d6-9736899fbc16]
+description = "encode and then decode -> encode followed by decode gives original string"

--- a/exercises/practice/say/.meta/tests.toml
+++ b/exercises/practice/say/.meta/tests.toml
@@ -1,0 +1,55 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5d22a120-ba0c-428c-bd25-8682235d83e8]
+description = "zero"
+
+[9b5eed77-dbf6-439d-b920-3f7eb58928f6]
+description = "one"
+
+[7c499be1-612e-4096-a5e1-43b2f719406d]
+description = "fourteen"
+
+[f541dd8e-f070-4329-92b4-b7ce2fcf06b4]
+description = "twenty"
+
+[d78601eb-4a84-4bfa-bf0e-665aeb8abe94]
+description = "twenty-two"
+
+[e417d452-129e-4056-bd5b-6eb1df334dce]
+description = "one hundred"
+
+[d6924f30-80ba-4597-acf6-ea3f16269da8]
+description = "one hundred twenty-three"
+
+[3d83da89-a372-46d3-b10d-de0c792432b3]
+description = "one thousand"
+
+[865af898-1d5b-495f-8ff0-2f06d3c73709]
+description = "one thousand two hundred thirty-four"
+
+[b6a3f442-266e-47a3-835d-7f8a35f6cf7f]
+description = "one million"
+
+[2cea9303-e77e-4212-b8ff-c39f1978fc70]
+description = "one million two thousand three hundred forty-five"
+
+[3e240eeb-f564-4b80-9421-db123f66a38f]
+description = "one billion"
+
+[9a43fed1-c875-4710-8286-5065d73b8a9e]
+description = "a big number"
+
+[49a6a17b-084e-423e-994d-a87c0ecc05ef]
+description = "numbers below zero are out of range"
+
+[4d6492eb-5853-4d16-9d34-b0f61b261fd9]
+description = "numbers above 999,999,999,999 are out of range"

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,0 +1,34 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
+
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
+
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
+
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
+
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
+
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
+
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
+
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8b2c43ac-7257-43f9-b552-7631a91988af]
+description = "equilateral triangle -> all sides are equal"
+
+[33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
+description = "equilateral triangle -> any side is unequal"
+
+[c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
+description = "equilateral triangle -> no sides are equal"
+
+[16e8ceb0-eadb-46d1-b892-c50327479251]
+description = "equilateral triangle -> all zero sides is not a triangle"
+
+[3022f537-b8e5-4cc1-8f12-fd775827a00c]
+description = "equilateral triangle -> sides may be floats"
+
+[cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
+description = "isosceles triangle -> last two sides are equal"
+
+[e388ce93-f25e-4daf-b977-4b7ede992217]
+description = "isosceles triangle -> first two sides are equal"
+
+[d2080b79-4523-4c3f-9d42-2da6e81ab30f]
+description = "isosceles triangle -> first and last sides are equal"
+
+[8d71e185-2bd7-4841-b7e1-71689a5491d8]
+description = "isosceles triangle -> equilateral triangles are also isosceles"
+
+[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
+description = "isosceles triangle -> no sides are equal"
+
+[2eba0cfb-6c65-4c40-8146-30b608905eae]
+description = "isosceles triangle -> first triangle inequality violation"
+
+[278469cb-ac6b-41f0-81d4-66d9b828f8ac]
+description = "isosceles triangle -> second triangle inequality violation"
+
+[90efb0c7-72bb-4514-b320-3a3892e278ff]
+description = "isosceles triangle -> third triangle inequality violation"
+
+[adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
+description = "isosceles triangle -> sides may be floats"
+
+[e8b5f09c-ec2e-47c1-abec-f35095733afb]
+description = "scalene triangle -> no sides are equal"
+
+[2510001f-b44d-4d18-9872-2303e7977dc1]
+description = "scalene triangle -> all sides are equal"
+
+[c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
+description = "scalene triangle -> two sides are equal"
+
+[70ad5154-0033-48b7-af2c-b8d739cd9fdc]
+description = "scalene triangle -> may not violate triangle inequality"
+
+[26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
+description = "scalene triangle -> sides may be floats"

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[61559d5f-2cad-48fb-af53-d3973a9ee9ef]
+description = "count one word"
+
+[5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
+description = "count one of each word"
+
+[2a3091e5-952e-4099-9fac-8f85d9655c0e]
+description = "multiple occurrences of a word"
+
+[e81877ae-d4da-4af4-931c-d923cd621ca6]
+description = "handles cramped lists"
+
+[7349f682-9707-47c0-a9af-be56e1e7ff30]
+description = "handles expanded lists"
+
+[a514a0f2-8589-4279-8892-887f76a14c82]
+description = "ignore punctuation"
+
+[d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
+description = "include numbers"
+
+[dac6bc6a-21ae-4954-945d-d7f716392dbf]
+description = "normalize case"
+
+[4185a902-bdb0-4074-864c-f416e42a0f19]
+description = "with apostrophes"
+
+[be72af2b-8afe-4337-b151-b297202e4a7b]
+description = "with quotations"
+
+[8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
+description = "substrings from the beginning"
+
+[c5f4ef26-f3f7-4725-b314-855c04fb4c13]
+description = "multiple spaces not detected as a word"
+
+[50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
+description = "alternating word separators not detected as a word"

--- a/exercises/practice/zipper/.meta/tests.toml
+++ b/exercises/practice/zipper/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[771c652e-0754-4ef0-945c-0675d12ef1f5]
+description = "data is retained"
+
+[d7dcbb92-47fc-4d01-b81a-df3353bc09ff]
+description = "left, right and value"
+
+[613d8286-b05c-4453-b205-e6f9c5966339]
+description = "dead end"
+
+[dda31af7-1c68-4e29-933a-c9d198d94284]
+description = "tree from deep focus"
+
+[1e3072a6-f85b-430b-b014-cdb4087e3577]
+description = "traversing up from top"
+
+[b8505f6a-aed4-4c2e-824f-a0ed8570d74b]
+description = "left, right, and up"
+
+[47df1a27-b709-496e-b381-63a03b82ea5f]
+description = "set_value"
+
+[16a1f1a8-dbed-456d-95ac-1cbb6093e0ab]
+description = "set_value after traversing up"
+
+[535a91af-a02e-49cd-8d2c-ecb6e4647174]
+description = "set_left with leaf"
+
+[b3f60c4b-a788-4ffd-be5d-1e69aee61de3]
+description = "set_right with null"
+
+[e91c221d-7b90-4604-b4ec-46638a673a12]
+description = "set_right with subtree"
+
+[c246be85-6648-4e9c-866f-b08cd495149a]
+description = "set_value on deep focus"
+
+[47aa85a0-5240-48a4-9f42-e2ac636710ea]
+description = "different paths to same zipper"


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
