### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [OCaml](https://ocaml.org/) is an industrial strength programming language supporting functional, imperative and object-oriented styles - but don't worry if you're not familiar with these, as it's used as a teaching language by a lot of institutions (including Cornell and Princeton). 
 
 One of the best features of OCaml is the rich and powerful [type system](https://en.wikipedia.org/wiki/Type_system) - this is useful to catch some mistakes early on saving developers a huge amount of frustration. 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 To work on the exercises, you will need these pieces of software:
 
 1. [`OPAM`, the OCaml Package manager](https://opam.ocaml.org/)

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for those learning OCaml for the first time. These resources can help you get started:
 
 * [Documentation for the Standard Library](http://caml.inria.fr/pub/docs/manual-ocaml/libref/index.html)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 * [Documentation for the Standard Library](http://caml.inria.fr/pub/docs/manual-ocaml/libref/index.html)
 * [OCaml at JaneStreet](https://ocaml.janestreet.com/)
 * [Documentation for the Core Library](https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Because OCaml is a compiled language you need to compile your submission and the test code before you can run the tests. 
 We use [`dune`](https://dune.build/) to build.
 Each folder has a dune file specifying how to build and also a Makefile which delegates to dune.

--- a/exercises/practice/atbash-cipher/.docs/instructions.append.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Deprecation of String.lowercase
+# Deprecation of String.lowercase
 Depending on the version of OCaml you installed the use of `String.lowercase` is
 frowned upon. Since version 4.03.0 `String.lowercase` is deprecated in favor of
 `String.lowercase_ascii`. So instead of writing 

--- a/exercises/practice/grade-school/.meta/description.md
+++ b/exercises/practice/grade-school/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Given students' names along with the grade that they are in, create a roster
 for the school.
 

--- a/exercises/practice/palindrome-products/.meta/description.md
+++ b/exercises/practice/palindrome-products/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Detect palindrome products in a given range.
 
 A palindromic number is a number that remains the same when its digits are

--- a/exercises/practice/react/HINT.md
+++ b/exercises/practice/react/HINT.md
@@ -1,3 +1,5 @@
+# Hint
+
 Feel free to change the interface if you think it can be improved.
 
 For instance, set_value can only be called on input cells, but the interface allows it to be called on compute cells (forcing a runtime check).

--- a/exercises/practice/zipper/HINT.md
+++ b/exercises/practice/zipper/HINT.md
@@ -1,4 +1,4 @@
-## [@@deriving sexp]
+# [@@deriving sexp]
 The file `tree.ml` uses the following expression: `[@@deriving sexp]`. This
 is described in (https://github.com/janestreet/pa_sexp_conv).
 

--- a/test-generator/README.md
+++ b/test-generator/README.md
@@ -1,3 +1,5 @@
+# Readme
+
 ## What does it do
 
 The test generator takes canonical-data.json files from the x-common folder, and


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
