### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "6a25c12e-16aa-413e-aee7-c046835ea115",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing OCaml locally",
+      "blurb": "Learn how to install OCaml locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "fd1f3884-9675-4606-b5a3-cbf9ea895d42",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn OCaml",
+      "blurb": "An overview of how to get started from scratch with OCaml"
+    },
+    {
+      "uuid": "8a520812-379f-407a-8a60-09a5cc95baa7",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the OCaml track",
+      "blurb": "Learn how to test your OCaml exercises on Exercism"
+    },
+    {
+      "uuid": "68c779f9-8221-4eb9-9f71-19fa97a6be38",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful OCaml resources",
+      "blurb": "A collection of useful resources to help you master OCaml"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
