### PR TITLE
Fixed Error

### DIFF
--- a/exercises/practice/palindrome-products/dune
+++ b/exercises/practice/palindrome-products/dune
@@ -1,8 +1,6 @@
 (executable
  (name test)
- (libraries base oUnit)
- (preprocess
-  (pps ppx_deriving.eq ppx_deriving.show)))
+ (libraries base oUnit))
 
 (alias
  (name runtest)


### PR DESCRIPTION
I got the following error message and thus I tried to fix it by referring other dune files.

File "dune", line 5, characters 7-22:
5 |   (pps ppx_deriving.eq ppx_deriving.show)))
           ^^^^^^^^^^^^^^^
Hint: try:
  dune external-lib-deps --missing @runtest
make: *** [Makefile:4: test] Error 1