### PR TITLE
Update indent size in editor configuration (config.json)

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4,
+    "indent_size": 2,
     "highlightjs_language": "ocaml"
   },
   "test_runner": {


### PR DESCRIPTION
The OCaml official manual and editor support modes use 2 spaces instead of 4.