### PR TITLE
Rework test-generator to use Core and remove getopts

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -13,6 +13,7 @@ RUN cd /home/opam/opam-repository \
 
 RUN opam update \
  && opam install core \
+                 core_unix \
                  merlin \
                  yaml \
                  ezjsonm \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # assignments
 ASSIGNMENT ?= ""
 ASSIGNMENTS = $(shell git ls-tree --name-only HEAD -- exercises/practice/ | awk -F/ '{print $$NF}' | sort)
+TEMPLATES = $(shell git ls-tree --name-only HEAD -- templates/ | awk -F/ '{print $$NF}' | sort)
+ASSIGNMENTS_GEN = $(TEMPLATES:=.gen)
 ASSIGNMENTS_DOCKER = $(ASSIGNMENTS:=.docker)
 
 default: testgenerator test
@@ -48,8 +50,10 @@ generator:
 test_generator: generator
 	dune runtest --root=./test-generator/
 
-generate_exercises:
-	dune exec ./bin_test_gen/test_gen.exe --root=./test-generator/
+$(ASSIGNMENTS_GEN): test_generator
+	dune exec ./bin_test_gen/test_gen.exe --root=./test-generator/ -- --exercise $(@:.gen=)
+	
+generate_exercises: $(ASSIGNMENTS_GEN)
 
 install_deps:
 	opam install dune fpath ocamlfind ounit qcheck react ppx_deriving ppx_let ppx_sexp_conv yojson ocp-indent calendar getopts

--- a/test-generator/bin_data_checker/canonical_data_checker.ml
+++ b/test-generator/bin_data_checker/canonical_data_checker.ml
@@ -1,19 +1,15 @@
-open Base
+open Core
 open Generator
 
-let data_folder_value = ref None
+let command =
+  Command.basic ~summary:"Reports errors in canonical data."
+    [%map_open.Command
+      let data_folder_value =
+        flag "c" (optional string) ~doc:"Directory containing canonical data."
+      in
+      fun () ->
+        data_folder_value
+        |> Option.value ~default:"../../../../problem-specifications/exercises"
+        |> Controller.check_canonical_data]
 
-let spec = Getopts.spec 
-  "[-c string]"
-  "Reports errors in canonical data."
-  [
-    Getopts.string 'c' (fun c _ -> data_folder_value := Some c) "Directory containing canonical data."
-  ] 
-  (fun _ _ -> ())
-  []
-
-let () =
-  Getopts.parse_argv spec ();
-  !data_folder_value 
-  |> Option.value ~default:"../../../../problem-specifications/exercises"
-  |> Controller.check_canonical_data;
+let () = Command_unix.run command

--- a/test-generator/bin_data_checker/dune
+++ b/test-generator/bin_data_checker/dune
@@ -1,8 +1,8 @@
 (executable
  (name canonical_data_checker)
- (libraries base getopts yojson generator)
+ (libraries core core_unix.command_unix generator)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving.show ppx_let)))
+  (pps ppx_jane)))
 
 (env
   (dev

--- a/test-generator/bin_debug/debug.ml
+++ b/test-generator/bin_debug/debug.ml
@@ -1,8 +1,12 @@
-open Base
-open Generator
+open! Core
+open! Generator
 
-let home_dir = Unix.getenv "HOME"
+(*
+let home_dir = match Sys.getenv "HOME" with
+  | Some x -> x
+  | None -> failwith "Environment variable \"HOME\" not set"
 
+(* This is not implemented at all *)
 let () =
   Controller.run
     ~templates_folder:"../templates/ocaml"
@@ -11,3 +15,4 @@ let () =
     ~generated_folder:(home_dir ^ "/.ocaml-generated")
     ~language_config:(Languages.default_language_config "ocaml")
     (Some "beer-song")
+*)

--- a/test-generator/bin_debug/debug.ml
+++ b/test-generator/bin_debug/debug.ml
@@ -11,8 +11,8 @@ let () =
   Controller.run
     ~templates_folder:"../templates/ocaml"
     ~canonical_data_folder:"../../../../problem-specifications/exercises"
-    ~output_folder:"../../exercises"
     ~generated_folder:(home_dir ^ "/.ocaml-generated")
     ~language_config:(Languages.default_language_config "ocaml")
+    "../../exercises"
     (Some "beer-song")
 *)

--- a/test-generator/bin_debug/dune
+++ b/test-generator/bin_debug/dune
@@ -1,8 +1,8 @@
 (executable
  (name debug)
- (libraries base oUnit yojson generator)
+ (libraries core generator)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving.show ppx_let)))
+  (pps ppx_jane)))
 
 (env
   (dev

--- a/test-generator/bin_test_gen/dune
+++ b/test-generator/bin_test_gen/dune
@@ -1,8 +1,8 @@
 (executable
  (name test_gen)
- (libraries base fpath getopts oUnit yojson generator)
+ (libraries core core_unix.command_unix generator)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving.show ppx_let)))
+  (pps ppx_jane)))
 
 (env
   (dev

--- a/test-generator/bin_test_gen/test_gen.ml
+++ b/test-generator/bin_test_gen/test_gen.ml
@@ -6,27 +6,39 @@ let command =
     [%map_open.Command
       let cwd =
         flag_optional_with_default_doc "w" string Sexp.of_string
+          ~aliases:["--cwd"]
           ~default:(Caml.Sys.getcwd ()) ~doc:"directory to assume as cwd"
       and templates_folder =
         flag_optional_with_default_doc "t" string Sexp.of_string
+          ~aliases:["--templates"]
           ~default:"./templates" ~doc:"directory containing templates"
       and canonical_data_folder =
         flag_optional_with_default_doc "c" string Sexp.of_string
+          ~aliases:["--canonical"]
           ~default:"./problem-specifications/exercises"
           ~doc:"directory containing data"
       and output_folder =
         flag_optional_with_default_doc "o" string Sexp.of_string
+          ~aliases:["--output"]
           ~default:"./exercises/practice"
           ~doc:"directory to output generated tests"
       and _ =
         flag "f" (optional string)
+          ~aliases:["--filter"]
           ~doc:"filter out files not matching this string"
+      and exercise =
+        flag "e" (optional string)
+          ~aliases:["--exercise"]
+          ~doc:"exercise to work on"
       in
       fun () ->
         Sys_unix.chdir cwd;
         ignore
-          (Controller.run ~templates_folder ~canonical_data_folder
-             ~output_folder
+          (Controller.run
+             ~templates_folder
+             ~canonical_data_folder
+             ?exercise
+             output_folder
           |> Result.ok_exn)]
 
 let () = Command_unix.run command

--- a/test-generator/bin_test_gen/test_gen.ml
+++ b/test-generator/bin_test_gen/test_gen.ml
@@ -1,47 +1,32 @@
-open Base
+open Core
 open Generator
 
-let home_dir = Unix.getenv "HOME"
+let command =
+  Command.basic ~summary:"Generates test code from canonical data."
+    [%map_open.Command
+      let cwd =
+        flag_optional_with_default_doc "w" string Sexp.of_string
+          ~default:(Caml.Sys.getcwd ()) ~doc:"directory to assume as cwd"
+      and templates_folder =
+        flag_optional_with_default_doc "t" string Sexp.of_string
+          ~default:"./templates" ~doc:"directory containing templates"
+      and canonical_data_folder =
+        flag_optional_with_default_doc "c" string Sexp.of_string
+          ~default:"./problem-specifications/exercises"
+          ~doc:"directory containing data"
+      and output_folder =
+        flag_optional_with_default_doc "o" string Sexp.of_string
+          ~default:"./exercises/practice"
+          ~doc:"directory to output generated tests"
+      and _ =
+        flag "f" (optional string)
+          ~doc:"filter out files not matching this string"
+      in
+      fun () ->
+        Sys_unix.chdir cwd;
+        ignore
+          (Controller.run ~templates_folder ~canonical_data_folder
+             ~output_folder
+          |> Result.ok_exn)]
 
-let cwd = ref (Caml.Sys.getcwd ())
-let template_value = ref None
-let data_folder_value = ref None
-let output_folder_value = ref None
-let filter_value = ref None
-
-let normalize_path (d: string): string =
-    d |> Fpath.of_string
-      |> Result.map_error ~f:(function `Msg m -> m)
-      |> Result.ok_or_failwith
-      |> Fpath.normalize
-      |> Fpath.to_string
-
-let get_path r d = 
-   let r' = Option.value !r ~default:d in
-   if Char.(d.[0] = '/') then d
-   else if Char.(r'.[0] = '/') then r'
-   else !cwd ^ "/" ^ r' |> normalize_path
-
-let spec = Getopts.spec 
-  "[-l string]"
-  "Generates test code from canonical data."
-  [
-    Getopts.string 'w' (fun w _ -> cwd := !cwd ^ w |> normalize_path) "directory to assume as cwd";
-    Getopts.string 't' (fun t _ -> template_value := Some t) "directory containing templates";
-    Getopts.string 'c' (fun c _ -> data_folder_value := Some c) "directory containing data";
-    Getopts.string 'o' (fun c _ -> output_folder_value := Some c) "directory to output generated tests";
-    Getopts.string 'f' (fun c _ -> filter_value := Some c) "filter out files not matching this string";
-  ] 
-  (fun _ _ -> ())
-  []
-
-let () =
-  Getopts.parse_argv spec ();
-  let templates_folder = get_path template_value "./templates" in
-  let canonical_data_folder = get_path data_folder_value "./problem-specifications/exercises" in
-  let output_folder = get_path output_folder_value "./exercises" in
-  ignore (Controller.run 
-    ~templates_folder
-    ~canonical_data_folder 
-    ~output_folder 
-  |> Result.ok_exn);
+let () = Command_unix.run command

--- a/test-generator/bin_test_gen/test_gen.ml
+++ b/test-generator/bin_test_gen/test_gen.ml
@@ -30,6 +30,11 @@ let command =
         flag "e" (optional string)
           ~aliases:["--exercise"]
           ~doc:"exercise to work on"
+      and filter_broken =
+        flag_optional_with_default_doc "b" bool Bool.sexp_of_t
+          ~aliases:["--filter-broken"]
+          ~default:false
+          ~doc:"filter_broken Weather or not to process templates with .broken"
       in
       fun () ->
         Sys_unix.chdir cwd;
@@ -38,6 +43,7 @@ let command =
              ~templates_folder
              ~canonical_data_folder
              ?exercise
+             ~filter_broken
              output_folder
           |> Result.ok_exn)]
 

--- a/test-generator/dune-project
+++ b/test-generator/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.6)
+(lang dune 3.0)

--- a/test-generator/lib_generator/canonical_data.ml
+++ b/test-generator/lib_generator/canonical_data.ml
@@ -1,3 +1,4 @@
+open Core
 type json = Yojson.Basic.t
 
 type t = {
@@ -9,7 +10,6 @@ type t = {
 
 let of_string (s: string): t =
   let open Yojson.Basic in
-  let open Base in
   let mem = fun k -> Util.member k (from_string s) in
   let version = (mem "version") |> Util.to_string in
   let exercise = (mem "exercise") |> Util.to_string in
@@ -42,7 +42,6 @@ let of_string (s: string): t =
   }
 
 let rec yo_to_ez (j: Yojson.Basic.t): Ezjsonm.value =
-  let open Base in
   match j with
   | `Null -> `Null
   | `Bool b -> `Bool b
@@ -53,7 +52,6 @@ let rec yo_to_ez (j: Yojson.Basic.t): Ezjsonm.value =
   | `Assoc l -> `O (List.map l ~f:(fun (k, v) -> (k, yo_to_ez v)))
 
 let to_json (d: t): Mustache.Json.t =
-  let open Base in
   `O [
     ("name", `String d.exercise);
     ("version", `String d.version);

--- a/test-generator/lib_generator/canonical_data.ml
+++ b/test-generator/lib_generator/canonical_data.ml
@@ -11,7 +11,7 @@ type t = {
 let of_string (s: string): t =
   let open Yojson.Basic in
   let mem = fun k -> Util.member k (from_string s) in
-  let version = (mem "version") |> Util.to_string in
+  let version = (mem "version") |> Util.to_string_option |> function Some x -> x | None -> "1.0" in
   let exercise = (mem "exercise") |> Util.to_string in
   let rec sanitize_cases (c: Yojson.Basic.t list): Yojson.Basic.t list =
     if List.for_all c ~f:(fun c -> Util.keys c |> List.exists ~f:(fun k -> String.(k = "cases"))) then

--- a/test-generator/lib_generator/controller.ml
+++ b/test-generator/lib_generator/controller.ml
@@ -1,17 +1,22 @@
-let run 
-  ~(templates_folder: string) 
-  ~(canonical_data_folder: string) 
+open Core
+
+let run
+  ~(templates_folder: string)
+  ~(canonical_data_folder: string)
   ~(output_folder: string) =
-    let open Base in
     Files.find_files canonical_data_folder ~glob:["*canonical-data.json"]
     |> List.map ~f:Exercise_candidate.of_path
     |> List.filter ~f:(fun (e: Exercise_candidate.t) -> e.is_implemented ~tpl:templates_folder)
     |> List.map ~f:(Exercise.of_candidate ~tpl:templates_folder ~out:output_folder)
     |> List.concat_map ~f:(fun (e: Exercise.t) ->
-      List.map e.templates ~f:(fun (t: Template.t) -> 
+      List.map e.templates ~f:(fun (t: Template.t) ->
         let path = Files.append_path output_folder t.relative_path |> Files.strip_ext in
-        Template.render t ~data:e.canonical_data 
+        Template.render t ~data:e.canonical_data
         |> (fun r -> if String.((Files.ext path) = ".ml") then Template.format r else r)
         |> Files.write_file ~path
       ))
     |> Result.all
+
+
+(* bin_data_checker calls this, but does not exist *)
+let check_canonical_data _ = failwith "not implemented"

--- a/test-generator/lib_generator/controller.ml
+++ b/test-generator/lib_generator/controller.ml
@@ -1,11 +1,18 @@
 open Core
 
 let run
-  ~(templates_folder: string)
-  ~(canonical_data_folder: string)
-  ~(output_folder: string) =
+    ?(exercise: string option)
+    ~(templates_folder: string)
+    ~(canonical_data_folder: string)
+    (output_folder: string) =
+
+    let exercise_filter = exercise |> function
+      | Some x -> fun (canidate: Exercise_candidate.t) -> String.equal x canidate.name
+      | None -> fun _ -> true
+    in
     Files.find_files canonical_data_folder ~glob:["*canonical-data.json"]
     |> List.map ~f:Exercise_candidate.of_path
+    |> List.filter ~f:exercise_filter
     |> List.filter ~f:(fun (e: Exercise_candidate.t) -> e.is_implemented ~tpl:templates_folder)
     |> List.map ~f:(Exercise.of_candidate ~tpl:templates_folder ~out:output_folder)
     |> List.concat_map ~f:(fun (e: Exercise.t) ->

--- a/test-generator/lib_generator/controller.ml
+++ b/test-generator/lib_generator/controller.ml
@@ -4,8 +4,10 @@ let run
     ?(exercise: string option)
     ~(templates_folder: string)
     ~(canonical_data_folder: string)
+    ?(filter_broken: bool option)
     (output_folder: string) =
 
+    let filter_broken = match filter_broken with Some x -> x | None -> false in
     let exercise_filter = exercise |> function
       | Some x -> fun (canidate: Exercise_candidate.t) -> String.equal x canidate.name
       | None -> fun _ -> true
@@ -13,6 +15,7 @@ let run
     Files.find_files canonical_data_folder ~glob:["*canonical-data.json"]
     |> List.map ~f:Exercise_candidate.of_path
     |> List.filter ~f:exercise_filter
+    |> List.filter ~f:(fun (e: Exercise_candidate.t) -> match filter_broken with | true -> not(e.is_broken ~tpl:templates_folder) | false -> true)
     |> List.filter ~f:(fun (e: Exercise_candidate.t) -> e.is_implemented ~tpl:templates_folder)
     |> List.map ~f:(Exercise.of_candidate ~tpl:templates_folder ~out:output_folder)
     |> List.concat_map ~f:(fun (e: Exercise.t) ->

--- a/test-generator/lib_generator/dune
+++ b/test-generator/lib_generator/dune
@@ -1,8 +1,8 @@
 (library
  (name generator)
- (libraries ezjsonm mustache base fpath stdio yojson ocp-indent.lib)
+ (libraries core core_unix ezjsonm mustache fpath yojson ocp-indent.lib)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving.show ppx_let)))
+  (pps ppx_jane)))
 
 (env
   (dev

--- a/test-generator/lib_generator/exercise.ml
+++ b/test-generator/lib_generator/exercise.ml
@@ -1,3 +1,5 @@
+open Core
+
 type t = {
   name: string; (* unique name *)
   directory: string; (* target directory *)
@@ -7,7 +9,6 @@ type t = {
 }
 
 let of_candidate ~(tpl: string) ~(out: string) (c: Exercise_candidate.t): t =
-  let open Base in
   {
     name = c.name;
     directory = Files.append_path out c.name;
@@ -17,14 +18,13 @@ let of_candidate ~(tpl: string) ~(out: string) (c: Exercise_candidate.t): t =
   }
 
 let to_string (e: t): string =
-  let open Base in
   let print_description = function
     | None -> "None"
-    | Some d -> Caml.Printf.sprintf "%s" d 
+    | Some d -> Caml.Printf.sprintf "%s" d
   in
-  Printf.sprintf "ExerciseCandidate { name = \"%s\"; directory = \"%s\"; description = \"%s\"; canonical_data = %s; templates = %s }" 
-    e.name 
-    e.directory 
+  Printf.sprintf "ExerciseCandidate { name = \"%s\"; directory = \"%s\"; description = \"%s\"; canonical_data = %s; templates = %s }"
+    e.name
+    e.directory
     (print_description e.description)
     (Canonical_data.to_string e.canonical_data)
     (List.map e.templates ~f:Template.to_string |> String.concat ~sep:"; ")

--- a/test-generator/lib_generator/exercise_candidate.ml
+++ b/test-generator/lib_generator/exercise_candidate.ml
@@ -1,3 +1,5 @@
+open Core
+
 type t = {
   name: string;
   directory: string;
@@ -9,13 +11,12 @@ type t = {
   has_templates: tpl:string -> bool;
 }
 
-let of_path (p: string): t = 
-  let open Base in
+let of_path (p: string): t =
   let name = Files.get_parent_name p in
   let directory = Files.get_parent_string p in
-  let get_template_files = fun ~tpl -> 
+  let get_template_files = fun ~tpl ->
     try Files.find_files (Files.append_path tpl name) ~glob:["*.tpl*"]
-    with Unix.Unix_error(Unix.ENOENT, _, _) -> [] 
+    with Core_unix.Unix_error(Core_unix.ENOENT, _, _) -> []
   in
   let get_templates = fun ~tpl -> get_template_files ~tpl |> List.map ~f:(Template.of_path ~tpl) in
   let get_data = fun () -> Files.read_file p |> Result.map ~f:Canonical_data.of_string in
@@ -23,8 +24,8 @@ let of_path (p: string): t =
   let has_data = fun () -> Files.read_file p |> Result.is_ok in
   let has_templates = fun ~tpl -> List.length (get_template_files ~tpl) > 0 in
   let is_implemented = fun ~tpl -> has_data () && has_templates ~tpl in
-  { 
-    name; 
+  {
+    name;
     directory;
     get_templates;
     get_data;
@@ -34,5 +35,5 @@ let of_path (p: string): t =
     has_templates;
   }
 
-let to_string (e: t): string = 
+let to_string (e: t): string =
   Printf.sprintf "ExerciseCandidate { name = \"%s\"; directory = \"%s\"; }" e.name e.directory

--- a/test-generator/lib_generator/files.ml
+++ b/test-generator/lib_generator/files.ml
@@ -60,6 +60,11 @@ let rec find_files (base: string) ~(glob: string list): string list =
     else
       [])
 
+let is_broken (p: string): bool =
+  match find_files p ~glob:[".broken"] with
+  | [] -> false
+  | _ -> true
+
 let get_parent (p: string): Fpath.t =
   path_exn p |> Fpath.parent
 

--- a/test-generator/lib_generator/generator.ml
+++ b/test-generator/lib_generator/generator.ml
@@ -13,3 +13,10 @@ end
 module Special_cases = struct
   include Special_cases
 end
+
+module Exercise_candidate = struct
+  include Exercise_candidate
+
+end
+
+module Exercise = Exercise

--- a/test-generator/lib_generator/glob.ml
+++ b/test-generator/lib_generator/glob.ml
@@ -1,12 +1,14 @@
+open Core
+
 let split c s =
 	let len = String.length s in
 	let rec loop acc last_pos pos =
 		if pos = -1 then
-		String.sub s 0 last_pos :: acc
+		Caml.String.sub s 0 last_pos :: acc
 		else
-		if s.[pos] = c then
+		if Char.equal (String.get s pos) c then
 			let pos1 = pos + 1 in
-			let sub_str = String.sub s pos1 (last_pos - pos1) in
+			let sub_str = Caml.String.sub s pos1 (last_pos - pos1) in
 			loop (sub_str :: acc) pos (pos - 1)
 		else loop acc last_pos (pos - 1)
 	in
@@ -19,7 +21,7 @@ let find_substrings ?(start_point=0) substr x =
 		if len_x - i < len_s
 		then acc
 		else
-			if String.sub x i len_s = substr
+			if String.equal (Caml.String.sub x i len_s) substr
 			then aux (i::acc) (i + 1)
 			else aux acc (i + 1)
 	in
@@ -27,16 +29,16 @@ let find_substrings ?(start_point=0) substr x =
 
 let matches glob x =
 	let rec contains_all_sections = function
-		| _, [] | _, [""] -> true 
+		| _, [] | _, [""] -> true
 		| i, [g] -> (* need to find a match that matches to end of string *)
 			find_substrings ~start_point:i g x
-			|> List.exists (fun j -> j + String.length g = String.length x)
+			|> List.exists ~f:(fun j -> j + String.length g = String.length x)
 		| 0, ""::g::gs ->
 			find_substrings g x
-			|> List.exists (fun j -> contains_all_sections ((j + (String.length g)), gs))
+			|> List.exists ~f:(fun j -> contains_all_sections ((j + (String.length g)), gs))
 		| i, g::gs ->
 			find_substrings ~start_point:i g x
-			|> List.exists (fun j ->
+			|> List.exists ~f:(fun j ->
 				(if i = 0 then j = 0 else true)
 				&& contains_all_sections ((j + (String.length g)), gs))
 	in

--- a/test-generator/lib_generator/model.ml
+++ b/test-generator/lib_generator/model.ml
@@ -1,4 +1,4 @@
-open Base
+open Core
 
 type json = Yojson.Basic.t
 
@@ -29,7 +29,7 @@ let rec json_to_string (j: json): string = match j with
   | `Assoc xs -> "[" ^ String.concat ~sep:"; "
                          (List.map xs ~f:(fun (k,v) -> "(\"" ^ String.escaped k ^ "\", " ^ json_to_string v ^ ")")) ^ "]"
 
-let list_to_string = String.concat ~sep:"; " 
+let list_to_string = String.concat ~sep:"; "
 
 let json_assoc_to_string (xs: (string * json) list): string =
   List.map xs ~f:(fun (k, j) -> k ^ ": " ^ (json_to_string j))
@@ -45,7 +45,7 @@ let test_to_string {name; cases}: string =
 
 let tests_to_string tests: string =
   "[" ^ list_to_string (List.map tests ~f:test_to_string) ^ "]"
-  
+
 let tests_to_string = function
 | Single case -> cases_to_string case
 | Suite tests -> tests_to_string tests

--- a/test-generator/lib_generator/special_cases.ml
+++ b/test-generator/lib_generator/special_cases.ml
@@ -1,4 +1,4 @@
-open Base
+open Core
 
 open Model
 open Yojson.Basic

--- a/test-generator/lib_generator/template.ml
+++ b/test-generator/lib_generator/template.ml
@@ -1,3 +1,5 @@
+open Core
+
 type t = {
   path: string;
   relative_path: string;
@@ -5,7 +7,6 @@ type t = {
 }
 
 let of_path (path: string) ~(tpl: string): t =
-  let open Base in
   let content = Files.read_file path |> Result.ok_exn in
   let relative_path = Files.relative_path tpl path in
   {
@@ -15,7 +16,6 @@ let of_path (path: string) ~(tpl: string): t =
   }
 
 let format (c: string): string =
-  let open Base in
   let b = Buffer.create (String.length c) in
   let o = { IndentPrinter.std_output with kind=(Print (fun s () -> Buffer.add_string b s)) } in
   IndentPrinter.proceed o (Nstream.of_string c) IndentBlock.empty ();
@@ -26,7 +26,6 @@ let format (c: string): string =
 
 let render (t: t) ~(data: Canonical_data.t): string =
   try
-    let open Base in
     Mustache.render (Mustache.of_string t.content) (Canonical_data.to_json data)
     |> String.substr_replace_all ~pattern:"&quot;" ~with_:"\""
     |> String.substr_replace_all ~pattern:"&apos;" ~with_:"\'"

--- a/test-generator/test/all_tests.ml
+++ b/test-generator/test/all_tests.ml
@@ -1,7 +1,10 @@
-open Base
+open! Core
 open OUnit2
 open Model_test
 open Special_cases_test
 
 let () =
-  run_test_tt_main ("tests" >:::List.concat [model_tests; special_cases_test;])
+  run_test_tt_main ("tests" >::: [
+      "model_tests" >::: model_tests;
+      "special_cases_test" >::: special_cases_test;
+    ])

--- a/test-generator/test/dune
+++ b/test-generator/test/dune
@@ -3,10 +3,8 @@
 
 (test
  (name all_tests)
- (libraries base stdio oUnit yojson generator)
- (deps (glob_files fixtures/*))
- (preprocess
-  (pps ppx_deriving.eq ppx_deriving.show ppx_let)))
+ (libraries core ounit2 yojson generator)
+ (deps (glob_files fixtures/*)))
 
 (env
   (dev

--- a/test-generator/test/model_test.ml
+++ b/test-generator/test/model_test.ml
@@ -1,4 +1,4 @@
-open Base
+open Core
 open OUnit2
 open Generator.Model
 

--- a/test-generator/test/special_cases_test.ml
+++ b/test-generator/test/special_cases_test.ml
@@ -1,4 +1,4 @@
-open Base
+open Core
 open OUnit2
 open Generator.Special_cases
 
@@ -37,7 +37,7 @@ let special_cases_test = [
   "option_of_null converts Null to None" >:: (fun _ctx ->
       assert_equal "None" @@ option_of_null `Null
     );
-  
+
   "option_of_null converts String to Some" >:: (fun _ctx ->
       assert_equal "(Some \"abc\")" @@ option_of_null (`String "abc")
     );


### PR DESCRIPTION
This started because getopts has a rather unusal system dependency of bmake. bmake, at least on Archlinux, requires fiddling with the MAKESYSPATH environment variable to work.

While working there, there was several code base inconsistencies and subtle bugs. Such as creating directories with permission 640 meanining that directories it created could not be accessed by the user that crated them.

All the commands had incorrect help text on that arguments they took as well, making it even more difficult to use.

There are still a bunch of stubs, but hopefully a more consistent codebase will make it easier for people to contribute.