### PR TITLE
Add mli interface files as readonly

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,6 +22,9 @@
     "solution": [
       "%{snake_slug}.ml"
     ],
+    "editor": [
+      "%{snake_slug}.mli"
+    ],
     "test": [
       "test.ml"
     ],

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "acronym.mli"
     ]
   },
   "blurb": "Convert a long phrase to its acronym.",

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "all_your_base.mli"
     ]
   },
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base."

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -16,6 +16,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "allergies.mli"
     ]
   },
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -24,6 +24,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "anagram.mli"
     ]
   },
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "atbash_cipher.mli"
     ]
   },
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "beer_song.mli"
     ]
   },
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -14,6 +14,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "binary_search_tree.mli"
     ]
   },
   "blurb": "Insert and search for numbers in a binary tree.",

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "binary_search.mli"
     ]
   },
   "blurb": "Implement a binary search algorithm.",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -25,6 +25,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "bob.mli"
     ]
   },
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -22,6 +22,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "bowling.mli"
     ]
   },
   "blurb": "Score a bowling game.",

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "change.mli"
     ]
   },
   "blurb": "Correctly determine change to be given using the least number of coins.",

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -18,6 +18,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "connect.mli"
     ]
   },
   "blurb": "Compute the result for a game of Hex / Polygon."

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "custom_set.mli"
     ]
   },
   "blurb": "Create a custom set type."

--- a/exercises/practice/custom-set/custom_set.mli
+++ b/exercises/practice/custom-set/custom_set.mli
@@ -1,0 +1,25 @@
+module type ELEMENT = sig
+  type t
+  val compare : t -> t -> int
+end
+
+module Make :
+  functor (El : ELEMENT) ->
+    sig
+      type t
+      type el = El.t
+      val el_equal : el -> el -> bool
+      val is_empty : t -> bool
+      val is_member : t -> el -> bool
+      val is_subset : t -> t -> bool
+      val is_disjoint : t -> t -> bool
+      val equal : t -> t -> bool
+      val of_list : El.t list -> t
+      val add : t -> el -> t
+      type status = [ `Both | `OnlyA | `OnlyB ]
+      val diff_filter :
+        (status -> bool) -> t -> t -> t
+      val difference : t -> t -> t
+      val intersect : t -> t -> t
+      val union : t -> t -> t
+    end

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "difference_of_squares.mli"
     ]
   },
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "dominoes.mli"
     ]
   },
   "blurb": "Make a chain of dominoes."

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "etl.mli"
     ]
   },
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "forth.mli"
     ]
   },
   "blurb": "Implement an evaluator for a very simple subset of Forth."

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -24,6 +24,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "grade_school.mli"
     ]
   },
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school.",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "hamming.mli"
     ]
   },
   "blurb": "Calculate the Hamming difference between two DNA strands.",

--- a/exercises/practice/hangman/.meta/config.json
+++ b/exercises/practice/hangman/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "hangman.mli"
     ]
   },
   "blurb": "Implement the logic of the hangman game using functional reactive programming."

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "hello_world.mli"
     ]
   },
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\".",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -24,6 +24,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "leap.mli"
     ]
   },
   "blurb": "Given a year, report if it is a leap year.",

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "list_ops.mli"
     ]
   },
   "blurb": "Implement basic list operations."

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -24,6 +24,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "luhn.mli"
     ]
   },
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -19,6 +19,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "matching_brackets.mli"
     ]
   },
   "blurb": "Make sure the brackets and braces all match.",

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "meetup.mli"
     ]
   },
   "blurb": "Calculate the date of meetups.",

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "minesweeper.mli"
     ]
   },
   "blurb": "Add the numbers to a minesweeper board."

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "nucleotide_count.mli"
     ]
   },
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -19,6 +19,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "palindrome_products.mli"
     ]
   },
   "blurb": "Detect palindrome products in a given range.",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -18,6 +18,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "pangram.mli"
     ]
   },
   "blurb": "Determine if a sentence is a pangram.",

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "phone_number.mli"
     ]
   },
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "prime_factors.mli"
     ]
   },
   "blurb": "Compute the prime factors of a given natural number.",

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "raindrops.mli"
     ]
   },
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "react.mli"
     ]
   },
   "blurb": "Implement a basic reactive system."

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "rectangles.mli"
     ]
   },
   "blurb": "Count the rectangles in an ASCII diagram."

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -24,6 +24,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "rna_transcription.mli"
     ]
   },
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -19,6 +19,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "robot_name.mli"
     ]
   },
   "blurb": "Manage robot factory settings.",

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "roman_numerals.mli"
     ]
   },
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "run_length_encoding.mli"
     ]
   },
   "blurb": "Implement run-length encoding and decoding.",

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -21,6 +21,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "say.mli"
     ]
   },
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "space_age.mli"
     ]
   },
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -20,6 +20,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "triangle.mli"
     ]
   },
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "word_count.mli"
     ]
   },
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -23,6 +23,9 @@
     ],
     "example": [
       ".meta/example.ml"
+    ],
+    "editor": [
+      "zipper.mli"
     ]
   },
   "blurb": "Creating a zipper for a binary tree."


### PR DESCRIPTION
The type signature of what the tests expect are in the mli files, but we don't show them to the user in the web view. This can make it very tricky for a user to know the shape of the function they are tasked with creating. These files should not be modified by the user as that will likely break the tests.

As per: https://exercism.org/docs/building/tracks/config-json

these "editor" files are read-only, but will show them to the user.