### PR TITLE
Update problem-specifications and sync all generated tests and mark broken templates.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test_generator: generator
 	dune runtest --root=./test-generator/
 
 $(ASSIGNMENTS_GEN): test_generator
-	dune exec ./bin_test_gen/test_gen.exe --root=./test-generator/ -- --exercise $(@:.gen=)
+	dune exec ./bin_test_gen/test_gen.exe --root=./test-generator/ -- --exercise $(@:.gen=) --filter-broken true
 	
 generate_exercises: $(ASSIGNMENTS_GEN)
 

--- a/exercises/practice/acronym/dune-project
+++ b/exercises/practice/acronym/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.7.0)

--- a/exercises/practice/acronym/test.ml
+++ b/exercises/practice/acronym/test.ml
@@ -1,4 +1,3 @@
-(* acronym - 1.7.0 *)
 open OUnit2
 open Acronym
 
@@ -6,6 +5,150 @@ let ae exp got _test_ctxt =
   assert_equal exp got ~printer:(fun x -> x )
 
 let tests = [
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
+  "basic" >::
+  ae "PNG" (acronym "Portable Network Graphics");
+  "lowercase words" >::
+  ae "ROR" (acronym "Ruby on Rails");
+  "punctuation" >::
+  ae "FIFO" (acronym "First In, First Out");
+  "all caps word" >::
+  ae "GIMP" (acronym "GNU Image Manipulation Program");
+  "punctuation without whitespace" >::
+  ae "CMOS" (acronym "Complementary metal-oxide semiconductor");
+  "very long abbreviation" >::
+  ae "ROTFLSHTMDCOALM" (acronym "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+  "consecutive delimiters" >::
+  ae "SIMUFTA" (acronym "Something - I made up from thin air");
+  "apostrophes" >::
+  ae "HC" (acronym "Halley's Comet");
+  "underscore emphasis" >::
+  ae "TRNT" (acronym "The Road _Not_ Taken");
   "basic" >::
   ae "PNG" (acronym "Portable Network Graphics");
   "lowercase words" >::

--- a/exercises/practice/all-your-base/dune-project
+++ b/exercises/practice/all-your-base/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 2.3.0)

--- a/exercises/practice/all-your-base/test.ml
+++ b/exercises/practice/all-your-base/test.ml
@@ -1,4 +1,3 @@
-(* all-your-base - 2.3.0 *)
 open OUnit2
 open All_your_base
 

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -155,3 +155,6 @@ description = "list when: -> everything"
 
 [12ce86de-b347-42a0-ab7c-2e0570f0c65b]
 description = "list when: -> no allergen score parts"
+
+[93c2df3e-4f55-4fed-8116-7513092819cd]
+description = "list when: -> no allergen score parts without highest valid score"

--- a/exercises/practice/allergies/dune-project
+++ b/exercises/practice/allergies/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 2.0.0)

--- a/exercises/practice/allergies/test.ml
+++ b/exercises/practice/allergies/test.ml
@@ -1,4 +1,3 @@
-(* allergies - 2.0.0 *)
 open Base
 open Allergies
 open OUnit2
@@ -178,6 +177,7 @@ let tests = [
   "lots of stuff" >:: aea [Strawberries; Tomatoes; Chocolate; Pollen; Cats] (allergies 248);
   "everything" >:: aea [Eggs; Peanuts; Shellfish; Strawberries; Tomatoes; Chocolate; Pollen; Cats] (allergies 255);
   "no allergen score parts" >:: aea [Eggs; Shellfish; Strawberries; Tomatoes; Chocolate; Pollen; Cats] (allergies 509);
+  "no allergen score parts without highest valid score" >:: aea [Eggs] (allergies 257);
 ]
 
 let qcheck_tests = List.map ~f:QCheck_ounit.to_ounit2_test [ prop_allergic_to_single_allergens

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -51,6 +51,24 @@ description = "anagrams must use all letters exactly once"
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
+include = false
+
+[68934ed0-010b-4ef9-857a-20c9012d1ebf]
+description = "words are not anagrams of themselves"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
+description = "words are not anagrams of themselves even if letter case is partially different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
+description = "words are not anagrams of themselves even if letter case is completely different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
+include = false
+
+[33d3f67e-fbb9-49d3-a90e-0beb00861da7]
+description = "words other than themselves can be anagrams"
+reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"

--- a/exercises/practice/anagram/dune-project
+++ b/exercises/practice/anagram/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.4.1)

--- a/exercises/practice/anagram/test.ml
+++ b/exercises/practice/anagram/test.ml
@@ -1,4 +1,3 @@
-(* anagram - 1.4.1 *)
 open Base
 open OUnit2
 open Anagram
@@ -12,12 +11,16 @@ let tests = [
   ae [] (anagrams "diaper" ["hello"; "world"; "zombies"; "pants"]);
   "detects two anagrams" >::
   ae ["stream"; "maters"] (anagrams "master" ["stream"; "pigeon"; "maters"]);
+  "detects two anagrams" >::
+  ae ["lemons"; "melons"] (anagrams "solemn" ["lemons"; "cherry"; "melons"]);
   "does not detect anagram subsets" >::
   ae [] (anagrams "good" ["dog"; "goody"]);
   "detects anagram" >::
   ae ["inlets"] (anagrams "listen" ["enlists"; "google"; "inlets"; "banana"]);
   "detects three anagrams" >::
   ae ["gallery"; "regally"; "largely"] (anagrams "allergy" ["gallery"; "ballerina"; "regally"; "clergy"; "largely"; "leading"]);
+  "detects multiple anagrams with different case" >::
+  ae ["Eons"; "ONES"] (anagrams "nose" ["Eons"; "ONES"]);
   "does not detect non-anagrams with identical checksum" >::
   ae [] (anagrams "mass" ["last"]);
   "detects anagrams case-insensitively" >::
@@ -32,6 +35,16 @@ let tests = [
   ae [] (anagrams "tapper" ["patter"]);
   "words are not anagrams of themselves (case-insensitive)" >::
   ae [] (anagrams "BANANA" ["BANANA"; "Banana"; "banana"]);
+  "words are not anagrams of themselves" >::
+  ae [] (anagrams "BANANA" ["BANANA"]);
+  "words are not anagrams of themselves even if letter case is partially different" >::
+  ae [] (anagrams "BANANA" ["Banana"]);
+  "words are not anagrams of themselves even if letter case is completely different" >::
+  ae [] (anagrams "BANANA" ["banana"]);
+  "words other than themselves can be anagrams" >::
+  ae ["Silent"] (anagrams "LISTEN" ["Listen"; "Silent"; "LISTEN"]);
+  "words other than themselves can be anagrams" >::
+  ae ["Silent"] (anagrams "LISTEN" ["LISTEN"; "Silent"]);
 ]
 
 let () =

--- a/exercises/practice/atbash-cipher/dune-project
+++ b/exercises/practice/atbash-cipher/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.2.0)

--- a/exercises/practice/atbash-cipher/test.ml
+++ b/exercises/practice/atbash-cipher/test.ml
@@ -1,4 +1,3 @@
-(* atbash-cipher - 1.2.0 *)
 open OUnit2
 open Atbash_cipher
 

--- a/exercises/practice/beer-song/dune-project
+++ b/exercises/practice/beer-song/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 2.1.0)

--- a/exercises/practice/beer-song/test.ml
+++ b/exercises/practice/beer-song/test.ml
@@ -1,4 +1,3 @@
-(* beer-song - 2.1.0 *)
 open Base
 open OUnit2
 open Beer_song

--- a/exercises/practice/binary-search/dune-project
+++ b/exercises/practice/binary-search/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.3.0)

--- a/exercises/practice/binary-search/test.ml
+++ b/exercises/practice/binary-search/test.ml
@@ -1,4 +1,3 @@
-(* binary-search - 1.3.0 *)
 open OUnit2
 open Binary_search
 

--- a/exercises/practice/bob/dune-project
+++ b/exercises/practice/bob/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.4.0)

--- a/exercises/practice/bob/test.ml
+++ b/exercises/practice/bob/test.ml
@@ -17,11 +17,11 @@ let tests = [
   "asking gibberish" >::
   ae "Sure." (response_for "fffbbcbeab?");
   "talking forcefully" >::
-  ae "Whatever." (response_for "Let's go make out behind the gym!");
+  ae "Whatever." (response_for "Hi there!");
   "using acronyms in regular speech" >::
-  ae "Whatever." (response_for "It's OK if you don't want to go to the DMV.");
+  ae "Whatever." (response_for "It's OK if you don't want to go work for NASA.");
   "forceful question" >::
-  ae "Calm down, I know what I'm doing!" (response_for "WHAT THE HELL WERE YOU THINKING?");
+  ae "Calm down, I know what I'm doing!" (response_for "WHAT'S GOING ON?");
   "shouting numbers" >::
   ae "Whoa, chill out!" (response_for "1, 2, 3 GO!");
   "no letters" >::
@@ -31,7 +31,7 @@ let tests = [
   "shouting with special characters" >::
   ae "Whoa, chill out!" (response_for "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!");
   "shouting with no exclamation mark" >::
-  ae "Whoa, chill out!" (response_for "I HATE THE DMV");
+  ae "Whoa, chill out!" (response_for "I HATE THE DENTIST");
   "statement containing question mark" >::
   ae "Whatever." (response_for "Ending with ? means a question.");
   "non-letters with question" >::

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -45,6 +45,9 @@ description = "rolling a spare with the two roll bonus does not get a bonus roll
 [576faac1-7cff-4029-ad72-c16bcada79b5]
 description = "strikes with the two roll bonus do not get bonus rolls"
 
+[efb426ec-7e15-42e6-9b96-b4fca3ec2359]
+description = "last two strikes followed by only last bonus with non strike points"
+
 [72e24404-b6c6-46af-b188-875514c0377b]
 description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
 

--- a/exercises/practice/bowling/dune-project
+++ b/exercises/practice/bowling/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.2.0)

--- a/exercises/practice/bowling/test.ml
+++ b/exercises/practice/bowling/test.ml
@@ -74,6 +74,10 @@ let tests = [
       let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 10; 10] in
       assert_score rolls (Ok 30)
     );
+  "last two strikes followed by only last bonus with non strike points" >:: (fun _ ->
+      let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 10; 10; 0; 1] in
+      assert_score rolls (Ok 31)
+    );
   "a strike with the one roll bonus after a spare in the last frame does not get a bonus" >:: (fun _ ->
       let rolls = [0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 7; 3; 10] in
       assert_score rolls (Ok 20)

--- a/exercises/practice/change/dune-project
+++ b/exercises/practice/change/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.3.0)

--- a/exercises/practice/change/test.ml
+++ b/exercises/practice/change/test.ml
@@ -9,6 +9,9 @@ let printer = function
 let ae exp got _test_ctxt = assert_equal ~printer exp got
 
 let tests = [
+  "change for 1 cent" >::
+  ae (Ok [1])
+    (make_change ~target:1 ~coins:[1; 5; 10; 25]);
   "single coin change" >::
   ae (Ok [25])
     (make_change ~target:25 ~coins:[1; 5; 10; 25; 100]);

--- a/exercises/practice/connect/dune-project
+++ b/exercises/practice/connect/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.1.0)

--- a/exercises/practice/custom-set/dune-project
+++ b/exercises/practice/custom-set/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.3.0)

--- a/exercises/practice/custom-set/test.ml
+++ b/exercises/practice/custom-set/test.ml
@@ -1,4 +1,3 @@
-(* custom-set - 1.3.0 *)
 open OUnit2
 
 module type EXPECTED = sig

--- a/exercises/practice/difference-of-squares/dune-project
+++ b/exercises/practice/difference-of-squares/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.2.0)

--- a/exercises/practice/dominoes/.meta/tests.toml
+++ b/exercises/practice/dominoes/.meta/tests.toml
@@ -44,3 +44,6 @@ description = "separate loops"
 
 [cd061538-6046-45a7-ace9-6708fe8f6504]
 description = "nine elements"
+
+[44704c7c-3adb-4d98-bd30-f45527cf8b49]
+description = "separate three-domino loops"

--- a/exercises/practice/dominoes/dune-project
+++ b/exercises/practice/dominoes/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 2.1.0)

--- a/exercises/practice/dominoes/test.ml
+++ b/exercises/practice/dominoes/test.ml
@@ -65,6 +65,8 @@ let tests = [
   assert_chain [(1,2); (2,3); (3,1); (1,1); (2,2); (3,3)] true;
   "nine elements" >::
   assert_chain [(1,2); (5,3); (3,1); (1,2); (2,4); (1,6); (2,3); (3,4); (5,6)] true;
+  "separate three-domino loops" >::
+  assert_chain [(1,2); (2,3); (3,1); (4,5); (5,6); (6,4)] false;
 ]
 
 let () =

--- a/exercises/practice/hello-world/dune-project
+++ b/exercises/practice/hello-world/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.1.0)

--- a/exercises/practice/hello-world/test.ml
+++ b/exercises/practice/hello-world/test.ml
@@ -1,4 +1,3 @@
-(* hello-world - 1.1.0 *)
 open OUnit2
 open Hello_world
 

--- a/exercises/practice/leap/dune-project
+++ b/exercises/practice/leap/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.5.1)

--- a/exercises/practice/leap/test.ml
+++ b/exercises/practice/leap/test.ml
@@ -1,4 +1,3 @@
-(* leap - 1.5.1 *)
 open OUnit2
 open Leap
 
@@ -11,10 +10,16 @@ let tests = [
   ae false (leap_year 1970);
   "year divisible by 4, not divisible by 100 in leap year" >::
   ae true (leap_year 1996);
+  "year divisible by 4 and 5 is still a leap year" >::
+  ae true (leap_year 1960);
   "year divisible by 100, not divisible by 400 in common year" >::
   ae false (leap_year 2100);
-  "year divisible by 400 in leap year" >::
+  "year divisible by 100 but not by 3 is still not a leap year" >::
+  ae false (leap_year 1900);
+  "year divisible by 400 is leap year" >::
   ae true (leap_year 2000);
+  "year divisible by 400 but not by 125 is still a leap year" >::
+  ae true (leap_year 2400);
   "year divisible by 200, not divisible by 400 in common year" >::
   ae false (leap_year 1800);
 ]

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -33,6 +33,9 @@ description = "invalid credit card"
 [20e67fad-2121-43ed-99a8-14b5b856adb9]
 description = "invalid long number with an even remainder"
 
+[7e7c9fc1-d994-457c-811e-d390d52fba5e]
+description = "invalid long number with a remainder divisible by 5"
+
 [ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
 description = "valid number with an even number of digits"
 
@@ -56,6 +59,12 @@ description = "more than a single zero is valid"
 
 [ab56fa80-5de8-4735-8a4a-14dae588663e]
 description = "input digit 9 is correctly converted to output digit 9"
+
+[b9887ee8-8337-46c5-bc45-3bcab51bc36f]
+description = "very long input is valid"
+
+[8a7c0e24-85ea-4154-9cf1-c2db90eabc08]
+description = "valid luhn with an odd number of digits and non zero first digit"
 
 [39a06a5a-5bad-4e0f-b215-b042d46209b1]
 description = "using ascii value for non-doubled non-digit isn't allowed"

--- a/exercises/practice/luhn/dune-project
+++ b/exercises/practice/luhn/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.6.1)

--- a/exercises/practice/luhn/test.ml
+++ b/exercises/practice/luhn/test.ml
@@ -1,4 +1,3 @@
-(* luhn - 1.6.1 *)
 open Base
 open OUnit2
 open Luhn
@@ -21,6 +20,10 @@ let tests = [
   assert_valid false "055 444 286";
   "invalid credit card" >::
   assert_valid false "8273 1232 7352 0569";
+  "invalid long number with an even remainder" >::
+  assert_valid false "1 2345 6789 1234 5678 9012";
+  "invalid long number with a remainder divisible by 5" >::
+  assert_valid false "1 2345 6789 1234 5678 9013";
   "valid number with an even number of digits" >::
   assert_valid true "095 245 88";
   "valid number with an odd number of spaces" >::
@@ -37,10 +40,16 @@ let tests = [
   assert_valid true "0000 0";
   "input digit 9 is correctly converted to output digit 9" >::
   assert_valid true "091";
+  "very long input is valid" >::
+  assert_valid true "9999999999 9999999999 9999999999 9999999999";
+  "valid luhn with an odd number of digits and non zero first digit" >::
+  assert_valid true "109";
   "using ascii value for non-doubled non-digit isn't allowed" >::
   assert_valid false "055b 444 285";
   "using ascii value for doubled non-digit isn't allowed" >::
   assert_valid false ":9";
+  "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed" >::
+  assert_valid false "59%59";
 ]
 
 let () =

--- a/exercises/practice/matching-brackets/.docs/instructions.md
+++ b/exercises/practice/matching-brackets/.docs/instructions.md
@@ -1,3 +1,4 @@
 # Instructions
 
 Given a string containing brackets `[]`, braces `{}`, parentheses `()`, or any combination thereof, verify that any and all pairs are matched and nested correctly.
+The string may also contain other characters, which for the purposes of this exercise should be ignored.

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -48,11 +48,20 @@ description = "unpaired and nested brackets"
 [a0205e34-c2ac-49e6-a88a-899508d7d68e]
 description = "paired and wrong nested brackets"
 
+[1d5c093f-fc84-41fb-8c2a-e052f9581602]
+description = "paired and wrong nested brackets but innermost are correct"
+
 [ef47c21b-bcfd-4998-844c-7ad5daad90a8]
 description = "paired and incomplete brackets"
 
 [a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
 description = "too many closing brackets"
+
+[a345a753-d889-4b7e-99ae-34ac85910d1a]
+description = "early unexpected brackets"
+
+[21f81d61-1608-465a-b850-baa44c5def83]
+description = "early mismatched brackets"
 
 [99255f93-261b-4435-a352-02bdecc9bdf2]
 description = "math expression"

--- a/exercises/practice/matching-brackets/dune-project
+++ b/exercises/practice/matching-brackets/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 2.0.0)

--- a/exercises/practice/matching-brackets/test.ml
+++ b/exercises/practice/matching-brackets/test.ml
@@ -32,10 +32,16 @@ let tests = [
   ae false (are_balanced "([{])");
   "paired and wrong nested brackets" >::
   ae false (are_balanced "[({]})");
+  "paired and wrong nested brackets but innermost are correct" >::
+  ae false (are_balanced "[({}])");
   "paired and incomplete brackets" >::
   ae false (are_balanced "{}[");
   "too many closing brackets" >::
   ae false (are_balanced "[]]");
+  "early unexpected brackets" >::
+  ae false (are_balanced ")()");
+  "early mismatched brackets" >::
+  ae false (are_balanced "{)()");
   "math expression" >::
   ae true (are_balanced "(((185 + 223.85) * 15) - 543)/2");
   "complex latex expression" >::

--- a/exercises/practice/minesweeper/dune-project
+++ b/exercises/practice/minesweeper/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.1.0)

--- a/exercises/practice/minesweeper/test.ml
+++ b/exercises/practice/minesweeper/test.ml
@@ -1,4 +1,3 @@
-(* minesweeper - 1.1.0 *)
 open Base
 open OUnit2
 open Minesweeper

--- a/exercises/practice/palindrome-products/.meta/tests.toml
+++ b/exercises/practice/palindrome-products/.meta/tests.toml
@@ -10,10 +10,10 @@
 # is regenerated, comments can be added via a `comment` key.
 
 [5cff78fe-cf02-459d-85c2-ce584679f887]
-description = "finds the smallest palindrome from single digit factors"
+description = "find the smallest palindrome from single digit factors"
 
 [0853f82c-5fc4-44ae-be38-fadb2cced92d]
-description = "finds the largest palindrome from single digit factors"
+description = "find the largest palindrome from single digit factors"
 
 [66c3b496-bdec-4103-9129-3fcb5a9063e1]
 description = "find the smallest palindrome from double digit factors"
@@ -22,13 +22,13 @@ description = "find the smallest palindrome from double digit factors"
 description = "find the largest palindrome from double digit factors"
 
 [cecb5a35-46d1-4666-9719-fa2c3af7499d]
-description = "find smallest palindrome from triple digit factors"
+description = "find the smallest palindrome from triple digit factors"
 
 [edab43e1-c35f-4ea3-8c55-2f31dddd92e5]
 description = "find the largest palindrome from triple digit factors"
 
 [4f802b5a-9d74-4026-a70f-b53ff9234e4e]
-description = "find smallest palindrome from four digit factors"
+description = "find the smallest palindrome from four digit factors"
 
 [787525e0-a5f9-40f3-8cb2-23b52cf5d0be]
 description = "find the largest palindrome from four digit factors"
@@ -44,3 +44,6 @@ description = "error result for smallest if min is more than max"
 
 [eeeb5bff-3f47-4b1e-892f-05829277bd74]
 description = "error result for largest if min is more than max"
+
+[16481711-26c4-42e0-9180-e2e4e8b29c23]
+description = "smallest product does not use the smallest factor"

--- a/exercises/practice/palindrome-products/dune-project
+++ b/exercises/practice/palindrome-products/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.2.0)

--- a/exercises/practice/palindrome-products/test.ml
+++ b/exercises/practice/palindrome-products/test.ml
@@ -1,4 +1,3 @@
-(* palindrome-products - 1.2.0 *)
 open OUnit2
 open Palindrome_products
 
@@ -15,10 +14,10 @@ let ae exp got _test_ctxt =
   assert_equal ~printer:(show_result show_palindrome_products) ~cmp:(eq_results equal_palindrome_products) exp got
 
 let tests = [
-  "finds the smallest palindrome from single digit factors" >::
+  "find the smallest palindrome from single digit factors" >::
   ae (Ok {value=(Some 1); factors=[(1,1)]})
     (smallest ~min:1 ~max:9);
-  "finds the largest palindrome from single digit factors" >::
+  "find the largest palindrome from single digit factors" >::
   ae (Ok {value=(Some 9); factors=[(1,9); (3,3)]})
     (largest ~min:1 ~max:9);
   "find the smallest palindrome from double digit factors" >::
@@ -27,13 +26,13 @@ let tests = [
   "find the largest palindrome from double digit factors" >::
   ae (Ok {value=(Some 9009); factors=[(91,99)]})
     (largest ~min:10 ~max:99);
-  "find smallest palindrome from triple digit factors" >::
+  "find the smallest palindrome from triple digit factors" >::
   ae (Ok {value=(Some 10201); factors=[(101,101)]})
     (smallest ~min:100 ~max:999);
   "find the largest palindrome from triple digit factors" >::
   ae (Ok {value=(Some 906609); factors=[(913,993)]})
     (largest ~min:100 ~max:999);
-  "find smallest palindrome from four digit factors" >::
+  "find the smallest palindrome from four digit factors" >::
   ae (Ok {value=(Some 1002001); factors=[(1001,1001)]})
     (smallest ~min:1000 ~max:9999);
   "find the largest palindrome from four digit factors" >::
@@ -51,6 +50,9 @@ let tests = [
   "error result for largest if min is more than max" >::
   ae (Error "min must be <= max")
     (largest ~min:2 ~max:1);
+  "smallest product does not use the smallest factor" >::
+  ae (Ok {value=(Some 10988901); factors=[(3297,3333)]})
+    (smallest ~min:3215 ~max:4000);
 ]
 
 let () =

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -38,3 +38,8 @@ description = "mixed case and punctuation"
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
+include = false
+
+[7138e389-83e4-4c6e-8413-1e40a0076951]
+description = "a-m and A-M are 26 different characters but not a pangram"
+reimplements = "2577bf54-83c8-402d-a64b-a2c0f7bb213a"

--- a/exercises/practice/pangram/dune-project
+++ b/exercises/practice/pangram/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.4.1)

--- a/exercises/practice/pangram/test.ml
+++ b/exercises/practice/pangram/test.ml
@@ -1,30 +1,251 @@
-(* pangram - 1.4.1 *)
 open OUnit2
 open Pangram
 
 let ae exp got _test_ctxt = assert_equal ~printer:string_of_bool exp got
 
 let tests = [
-  "sentence empty" >::
+  "empty sentence" >::
   ae false (is_pangram "");
-  "recognizes a perfect lower case pangram" >::
+  "perfect lower case" >::
   ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
-  "pangram with only lower case" >::
+  "only lower case" >::
   ae true (is_pangram "the quick brown fox jumps over the lazy dog");
-  "missing character 'x'" >::
+  "missing the letter 'x'" >::
   ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
-  "another missing character, e.g. 'h'" >::
+  "missing the letter 'h'" >::
   ae false (is_pangram "five boxing wizards jump quickly at it");
-  "pangram with underscores" >::
+  "with underscores" >::
   ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
-  "pangram with numbers" >::
+  "with numbers" >::
   ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
   "missing letters replaced by numbers" >::
   ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
-  "pangram with mixed case and punctuation" >::
+  "mixed case and punctuation" >::
   ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
-  "upper and lower case versions of the same character should not be counted separately" >::
+  "case insensitive" >::
   ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
+  "empty sentence" >::
+  ae false (is_pangram "");
+  "perfect lower case" >::
+  ae true (is_pangram "abcdefghijklmnopqrstuvwxyz");
+  "only lower case" >::
+  ae true (is_pangram "the quick brown fox jumps over the lazy dog");
+  "missing the letter 'x'" >::
+  ae false (is_pangram "a quick movement of the enemy will jeopardize five gunboats");
+  "missing the letter 'h'" >::
+  ae false (is_pangram "five boxing wizards jump quickly at it");
+  "with underscores" >::
+  ae true (is_pangram "the_quick_brown_fox_jumps_over_the_lazy_dog");
+  "with numbers" >::
+  ae true (is_pangram "the 1 quick brown fox jumps over the 2 lazy dogs");
+  "missing letters replaced by numbers" >::
+  ae false (is_pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog");
+  "mixed case and punctuation" >::
+  ae true (is_pangram "\"Five quacking Zephyrs jolt my wax bed.\"");
+  "case insensitive" >::
+  ae false (is_pangram "the quick brown fox jumps over with lazy FX");
+  "a-m and A-M are 26 different characters but not a pangram" >::
+  ae false (is_pangram "abcdefghijklm ABCDEFGHIJKLM");
 ]
 
 let () =

--- a/exercises/practice/prime-factors/dune-project
+++ b/exercises/practice/prime-factors/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.1.0)

--- a/exercises/practice/prime-factors/test.ml
+++ b/exercises/practice/prime-factors/test.ml
@@ -1,4 +1,3 @@
-(* prime-factors - 1.1.0 *)
 open Base
 open OUnit2
 open Prime_factors
@@ -20,10 +19,284 @@ let tests = [
   ae (to_int64s []) (factors_of 1L);
   "prime number" >::
   ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
   "square of a prime" >::
   ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
   "cube of a prime" >::
   ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
+  "product of primes and non-primes" >::
+  ae (to_int64s [2; 2; 3]) (factors_of 12L);
+  "product of primes" >::
+  ae (to_int64s [5; 17; 23; 461]) (factors_of 901255L);
+  "factors include a large prime" >::
+  ae (to_int64s [11; 9539; 894119]) (factors_of 93819012551L);
+  "no factors" >::
+  ae (to_int64s []) (factors_of 1L);
+  "prime number" >::
+  ae (to_int64s [2]) (factors_of 2L);
+  "another prime number" >::
+  ae (to_int64s [3]) (factors_of 3L);
+  "square of a prime" >::
+  ae (to_int64s [3; 3]) (factors_of 9L);
+  "product of first prime" >::
+  ae (to_int64s [2; 2]) (factors_of 4L);
+  "cube of a prime" >::
+  ae (to_int64s [2; 2; 2]) (factors_of 8L);
+  "product of second prime" >::
+  ae (to_int64s [3; 3; 3]) (factors_of 27L);
+  "product of third prime" >::
+  ae (to_int64s [5; 5; 5; 5]) (factors_of 625L);
+  "product of first and second prime" >::
+  ae (to_int64s [2; 3]) (factors_of 6L);
   "product of primes and non-primes" >::
   ae (to_int64s [2; 2; 3]) (factors_of 12L);
   "product of primes" >::

--- a/exercises/practice/raindrops/dune-project
+++ b/exercises/practice/raindrops/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.1.0)

--- a/exercises/practice/raindrops/test.ml
+++ b/exercises/practice/raindrops/test.ml
@@ -1,4 +1,3 @@
-(* raindrops - 1.1.0 *)
 open OUnit2
 open Raindrops
 

--- a/exercises/practice/rectangles/.meta/tests.toml
+++ b/exercises/practice/rectangles/.meta/tests.toml
@@ -47,3 +47,6 @@ description = "corner is required for a rectangle to be complete"
 
 [d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66]
 description = "large input with many rectangles"
+
+[6ef24e0f-d191-46da-b929-4faca24b4cd2]
+description = "rectangles must have four sides"

--- a/exercises/practice/rectangles/dune-project
+++ b/exercises/practice/rectangles/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.1.0)

--- a/exercises/practice/rectangles/test.ml
+++ b/exercises/practice/rectangles/test.ml
@@ -1,4 +1,3 @@
-(* rectangles - 1.1.0 *)
 open OUnit2
 open Rectangles
 
@@ -83,6 +82,16 @@ let tests = [
       "+---+--+--+-+";
       "+------+  | |";
       "          +-+";
+    |]);
+  "rectangles must have four sides" >::
+  ae 5 (count_rectangles [|
+      "+-+ +-+";
+      "| | | |";
+      "+-+-+-+";
+      "  | |  ";
+      "+-+-+-+";
+      "| | | |";
+      "+-+ +-+";
     |]);
 ]
 

--- a/exercises/practice/run-length-encoding/dune-project
+++ b/exercises/practice/run-length-encoding/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.1.0)

--- a/exercises/practice/run-length-encoding/test.ml
+++ b/exercises/practice/run-length-encoding/test.ml
@@ -1,4 +1,3 @@
-(* run-length-encoding - 1.1.0 *)
 open Base
 open OUnit2
 open Run_length_encoding
@@ -30,7 +29,7 @@ let decode_tests = [
   ae "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB" ("12WB12W3B24WB" |> decode);
   "multiple whitespace mixed in string" >::
   ae "  hsqq qww  " ("2 hs2q q2w2 " |> decode);
-  "lower case string" >::
+  "lowercase string" >::
   ae "aabbbcccc" ("2a3b4c" |> decode);
 ]
 let encode_and_then_decode_tests = [

--- a/exercises/practice/say/.docs/instructions.md
+++ b/exercises/practice/say/.docs/instructions.md
@@ -48,13 +48,3 @@ Put it all together to get nothing but plain English.
 `12345` should give `twelve thousand three hundred forty-five`.
 
 The program must also report any values that are out of range.
-
-### Extensions
-
-Use _and_ (correctly) when spelling out the number in English:
-
-- 14 becomes "fourteen".
-- 100 becomes "one hundred".
-- 120 becomes "one hundred and twenty".
-- 1002 becomes "one thousand and two".
-- 1323 becomes "one thousand three hundred and twenty-three".

--- a/exercises/practice/say/.meta/tests.toml
+++ b/exercises/practice/say/.meta/tests.toml
@@ -24,11 +24,23 @@ description = "twenty"
 [d78601eb-4a84-4bfa-bf0e-665aeb8abe94]
 description = "twenty-two"
 
+[f010d4ca-12c9-44e9-803a-27789841adb1]
+description = "thirty"
+
+[738ce12d-ee5c-4dfb-ad26-534753a98327]
+description = "ninety-nine"
+
 [e417d452-129e-4056-bd5b-6eb1df334dce]
 description = "one hundred"
 
 [d6924f30-80ba-4597-acf6-ea3f16269da8]
 description = "one hundred twenty-three"
+
+[2f061132-54bc-4fd4-b5df-0a3b778959b9]
+description = "two hundred"
+
+[feed6627-5387-4d38-9692-87c0dbc55c33]
+description = "nine hundred ninety-nine"
 
 [3d83da89-a372-46d3-b10d-de0c792432b3]
 description = "one thousand"

--- a/exercises/practice/say/dune-project
+++ b/exercises/practice/say/dune-project
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version 1.2.0)

--- a/exercises/practice/say/test.ml
+++ b/exercises/practice/say/test.ml
@@ -1,4 +1,3 @@
-(* say - 1.2.0 *)
 open Base
 open OUnit2
 open Say
@@ -20,10 +19,18 @@ let tests = [
   ae (Ok "twenty") (in_english 20L);
   "twenty-two" >::
   ae (Ok "twenty-two") (in_english 22L);
+  "thirty" >::
+  ae (Ok "thirty") (in_english 30L);
+  "ninety-nine" >::
+  ae (Ok "ninety-nine") (in_english 99L);
   "one hundred" >::
   ae (Ok "one hundred") (in_english 100L);
   "one hundred twenty-three" >::
   ae (Ok "one hundred twenty-three") (in_english 123L);
+  "two hundred" >::
+  ae (Ok "two hundred") (in_english 200L);
+  "nine hundred ninety-nine" >::
+  ae (Ok "nine hundred ninety-nine") (in_english 999L);
   "one thousand" >::
   ae (Ok "one thousand") (in_english 1000L);
   "one thousand two hundred thirty-four" >::

--- a/templates/acronym/dune-project.tpl
+++ b/templates/acronym/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/acronym/test.ml.tpl
+++ b/templates/acronym/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Acronym
 

--- a/templates/all-your-base/dune-project.tpl
+++ b/templates/all-your-base/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/all-your-base/test.ml.tpl
+++ b/templates/all-your-base/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open All_your_base
 

--- a/templates/allergies/dune-project.tpl
+++ b/templates/allergies/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/allergies/test.ml.tpl
+++ b/templates/allergies/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open Allergies
 open OUnit2

--- a/templates/anagram/dune-project.tpl
+++ b/templates/anagram/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/anagram/test.ml.tpl
+++ b/templates/anagram/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open OUnit2
 open Anagram

--- a/templates/atbash-cipher/dune-project.tpl
+++ b/templates/atbash-cipher/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/atbash-cipher/test.ml.tpl
+++ b/templates/atbash-cipher/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Atbash_cipher
 

--- a/templates/beer-song/dune-project.tpl
+++ b/templates/beer-song/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/beer-song/test.ml.tpl
+++ b/templates/beer-song/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open OUnit2
 open Beer_song

--- a/templates/binary-search/dune-project.tpl
+++ b/templates/binary-search/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/binary-search/test.ml.tpl
+++ b/templates/binary-search/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Binary_search
 

--- a/templates/bob/dune-project.tpl
+++ b/templates/bob/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/bowling/dune-project.tpl
+++ b/templates/bowling/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/change/dune-project.tpl
+++ b/templates/change/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/connect/dune-project.tpl
+++ b/templates/connect/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/custom-set/dune-project.tpl
+++ b/templates/custom-set/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/custom-set/test.ml.tpl
+++ b/templates/custom-set/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 
 module type EXPECTED = sig

--- a/templates/difference-of-squares/dune-project.tpl
+++ b/templates/difference-of-squares/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/dominoes/dune-project.tpl
+++ b/templates/dominoes/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/etl/.broken
+++ b/templates/etl/.broken
@@ -1,0 +1,192 @@
+----------------------------------------------------------------
+running tests for: etl
+File "dune", line 5, characters 0-76:
+5 | (alias
+6 |   (name    runtest)
+7 |   (deps    (:x test.exe))
+8 |   (action  (run %{x})))
+FFFFFFFFFFFFFFFF
+==============================================================================
+Error: etl tests:15:multiple scores with differing numbers of letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#08.log", line 10, characters 1-1:
+Error: etl tests:15:multiple scores with differing numbers of letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(b,3);(c,3);(d,2);(e,1);(f,4);(g,2);(h,4);(i,1);(j,8);(k,5);(l,1);(m,3);(n,1);(o,1);(p,3);(q,10);(r,1);(s,1);(t,1);(u,1);(v,4);(w,4);(x,8);(y,4);(z,10)
+but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:14:multiple scores with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#01.log", line 9, characters 1-1:
+Error: etl tests:14:multiple scores with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(d,2);(e,1);(g,2) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:13:single score with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#02.log", line 9, characters 1-1:
+Error: etl tests:13:single score with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(e,1);(i,1);(o,1);(u,1) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:12:single letter.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#03.log", line 9, characters 1-1:
+Error: etl tests:12:single letter (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:11:multiple scores with differing numbers of letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#04.log", line 10, characters 1-1:
+Error: etl tests:11:multiple scores with differing numbers of letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(b,3);(c,3);(d,2);(e,1);(f,4);(g,2);(h,4);(i,1);(j,8);(k,5);(l,1);(m,3);(n,1);(o,1);(p,3);(q,10);(r,1);(s,1);(t,1);(u,1);(v,4);(w,4);(x,8);(y,4);(z,10)
+but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:10:multiple scores with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#05.log", line 9, characters 1-1:
+Error: etl tests:10:multiple scores with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(d,2);(e,1);(g,2) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:9:single score with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#06.log", line 9, characters 1-1:
+Error: etl tests:9:single score with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(e,1);(i,1);(o,1);(u,1) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:8:single letter.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#07.log", line 9, characters 1-1:
+Error: etl tests:8:single letter (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:7:multiple scores with differing numbers of letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#08.log", line 2, characters 1-1:
+Error: etl tests:7:multiple scores with differing numbers of letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(b,3);(c,3);(d,2);(e,1);(f,4);(g,2);(h,4);(i,1);(j,8);(k,5);(l,1);(m,3);(n,1);(o,1);(p,3);(q,10);(r,1);(s,1);(t,1);(u,1);(v,4);(w,4);(x,8);(y,4);(z,10)
+but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:6:multiple scores with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#07.log", line 2, characters 1-1:
+Error: etl tests:6:multiple scores with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(d,2);(e,1);(g,2) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:5:single score with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#06.log", line 2, characters 1-1:
+Error: etl tests:5:single score with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(e,1);(i,1);(o,1);(u,1) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:4:single letter.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#05.log", line 2, characters 1-1:
+Error: etl tests:4:single letter (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:3:multiple scores with differing numbers of letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#04.log", line 2, characters 1-1:
+Error: etl tests:3:multiple scores with differing numbers of letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(b,3);(c,3);(d,2);(e,1);(f,4);(g,2);(h,4);(i,1);(j,8);(k,5);(l,1);(m,3);(n,1);(o,1);(p,3);(q,10);(r,1);(s,1);(t,1);(u,1);(v,4);(w,4);(x,8);(y,4);(z,10)
+but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:2:multiple scores with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#03.log", line 2, characters 1-1:
+Error: etl tests:2:multiple scores with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(d,2);(e,1);(g,2) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:1:single score with multiple letters.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#02.log", line 2, characters 1-1:
+Error: etl tests:1:single score with multiple letters (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1);(e,1);(i,1);(o,1);(u,1) but got: 
+------------------------------------------------------------------------------
+==============================================================================
+Error: etl tests:0:single letter.
+
+File "/tmp/etl.lx7k1BZlis/_build/oUnit-etl tests-#01.log", line 2, characters 1-1:
+Error: etl tests:0:single letter (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: (a,1) but got: 
+------------------------------------------------------------------------------
+Ran: 16 tests in: 0.10 seconds.
+FAILED: Cases: 16 Tried: 16 Errors: 0 Failures: 16 Skip:  0 Todo: 0 Timeouts: 0.
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/forth/.broken
+++ b/templates/forth/.broken
@@ -1,0 +1,55 @@
+forth/test.ml.tpl
+======
+open Base
+open OUnit2
+open Forth
+
+let print_int_list_option (xs: int list option) = match xs with
+| None -> "None"
+| Some xs -> "Some [" ^ String.concat ~sep:";" (List.map ~f:Int.to_string xs) ^ "]"
+let ae exp got _test_ctxt = assert_equal ~printer:print_int_list_option exp got
+
+{{#cases}}
+  let {{slug}}_tests = [
+    {{#cases}}
+      "{{description}}" >::
+        ae {{#input}}{{expected}} ({{property}} {{instructions}}){{/input}};
+    {{/cases}}
+  ]
+
+
+{{/cases}}
+
+let () =
+  run_test_tt_main (
+    "forth tests" >:::
+      List.concat [
+        {{#cases}}
+          {{slug}}_tests;
+        {{/cases}}
+      ]
+  )
+Uncaught exception:
+  
+  Mustache_types.Missing_variable("instructions")
+
+Raised at Mustache.Lookup.dotted_name.(fun) in file "lib/mustache.ml", line 176, characters 25-51
+Called from Mustache.Lookup.str.(fun) in file "lib/mustache.ml", line 179, characters 10-37
+Called from Mustache.Without_locations.render_fmt.(fun).render' in file "lib/mustache.ml", line 310, characters 48-81
+Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
+Called from Mustache.Without_locations.render in file "lib/mustache.ml", line 345, characters 4-41
+Called from Generator__Template.render in file "lib_generator/template.ml", line 29, characters 4-80
+Re-raised at Generator__Template.render in file "lib_generator/template.ml", line 37, characters 4-13
+Called from Generator__Controller.run.(fun) in file "lib_generator/controller.ml", line 24, characters 8-48
+Called from Base__List.count_map in file "src/list.ml", line 465, characters 13-17
+Called from Base__List.concat_map.aux in file "src/list.ml", line 709, characters 34-40
+Called from Generator__Controller.run in file "lib_generator/controller.ml", line 15, characters 4-858
+Called from Dune__exe__Test_gen.command.(fun) in file "bin_test_gen/test_gen.ml", line 42, characters 11-170
+Called from Core__Command.For_unix.run.(fun) in file "core/src/command.ml", line 2871, characters 8-270
+Called from Base__Exn.handle_uncaught_aux in file "src/exn.ml", line 127, characters 6-10
+make: *** [Makefile:49: forth.gen] Error 1

--- a/templates/grade-school/.broken
+++ b/templates/grade-school/.broken
@@ -1,0 +1,9 @@
+----------------------------------------------------------------
+running tests for: grade-school
+File "test.ml", line 15, characters 24-28:
+15 |     assert_lists_equal [true] (add school)
+                             ^^^^
+Error: This expression has type bool but an expression was expected of type
+         string
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/hamming/.broken
+++ b/templates/hamming/.broken
@@ -1,0 +1,84 @@
+----------------------------------------------------------------
+running tests for: hamming
+File "dune", line 5, characters 0-76:
+5 | (alias
+6 |   (name    runtest)
+7 |   (deps    (:x test.exe))
+8 |   (action  (run %{x})))
+.F.FFF..F..F...
+==============================================================================
+Error: hamming tests:14:disallow empty second strand.
+
+File "/tmp/hamming.Hx110eQ9cL/_build/oUnit-hamming tests-#03.log", line 5, characters 1-1:
+Error: hamming tests:14:disallow empty second strand (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "strands must be of equal length"
+but got: Error "right strand must not be empty"
+------------------------------------------------------------------------------
+==============================================================================
+Error: hamming tests:13:disallow right empty strand.
+
+File "/tmp/hamming.Hx110eQ9cL/_build/oUnit-hamming tests-#07.log", line 26, characters 1-1:
+Error: hamming tests:13:disallow right empty strand (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "left and right strands must be of equal length"
+but got: Error "right strand must not be empty"
+------------------------------------------------------------------------------
+==============================================================================
+Error: hamming tests:11:disallow empty first strand.
+
+File "/tmp/hamming.Hx110eQ9cL/_build/oUnit-hamming tests-#02.log", line 5, characters 1-1:
+Error: hamming tests:11:disallow empty first strand (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "strands must be of equal length"
+but got: Error "left strand must not be empty"
+------------------------------------------------------------------------------
+==============================================================================
+Error: hamming tests:10:disallow left empty strand.
+
+File "/tmp/hamming.Hx110eQ9cL/_build/oUnit-hamming tests-#07.log", line 18, characters 1-1:
+Error: hamming tests:10:disallow left empty strand (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "left and right strands must be of equal length"
+but got: Error "left strand must not be empty"
+------------------------------------------------------------------------------
+==============================================================================
+Error: hamming tests:8:disallow second strand longer.
+
+File "/tmp/hamming.Hx110eQ9cL/_build/oUnit-hamming tests-#07.log", line 10, characters 1-1:
+Error: hamming tests:8:disallow second strand longer (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "strands must be of equal length"
+but got: Error "left and right strands must be of equal length"
+------------------------------------------------------------------------------
+==============================================================================
+Error: hamming tests:6:disallow first strand longer.
+
+File "/tmp/hamming.Hx110eQ9cL/_build/oUnit-hamming tests-#07.log", line 2, characters 1-1:
+Error: hamming tests:6:disallow first strand longer (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "strands must be of equal length"
+but got: Error "left and right strands must be of equal length"
+------------------------------------------------------------------------------
+Ran: 15 tests in: 0.10 seconds.
+FAILED: Cases: 15 Tried: 15 Errors: 0 Failures: 6 Skip:  0 Todo: 0 Timeouts: 0.
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/hello-world/dune-project.tpl
+++ b/templates/hello-world/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/hello-world/test.ml.tpl
+++ b/templates/hello-world/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Hello_world
 

--- a/templates/leap/dune-project.tpl
+++ b/templates/leap/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/leap/test.ml.tpl
+++ b/templates/leap/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Leap
 

--- a/templates/luhn/dune-project.tpl
+++ b/templates/luhn/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/luhn/test.ml.tpl
+++ b/templates/luhn/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open OUnit2
 open Luhn

--- a/templates/matching-brackets/dune-project.tpl
+++ b/templates/matching-brackets/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/minesweeper/dune-project.tpl
+++ b/templates/minesweeper/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/minesweeper/test.ml.tpl
+++ b/templates/minesweeper/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open OUnit2
 open Minesweeper

--- a/templates/palindrome-products/dune-project.tpl
+++ b/templates/palindrome-products/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/palindrome-products/test.ml.tpl
+++ b/templates/palindrome-products/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Palindrome_products
 

--- a/templates/pangram/dune-project.tpl
+++ b/templates/pangram/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/pangram/test.ml.tpl
+++ b/templates/pangram/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Pangram
 

--- a/templates/phone-number/.broken
+++ b/templates/phone-number/.broken
@@ -1,0 +1,540 @@
+----------------------------------------------------------------
+running tests for: phone-number
+File "dune", line 5, characters 0-76:
+5 | (alias
+6 |   (name    runtest)
+7 |   (deps    (:x test.exe))
+8 |   (action  (run %{x})))
+....F...F................F..F...................FF..................F...F................F....F..................F....F..............F...F..............F........F................F...F.................F....F................F...F..............F....F..................F...F..............F.....F.................F..F...................F...F................F...F.................F....F...............F....F................F....F...............F.....F................F...F..................
+==============================================================================
+Error: phone-number tests:471:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#06.log", line 213, characters 1-1:
+Error: phone-number tests:471:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:466:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#01.log", line 202, characters 1-1:
+Error: phone-number tests:466:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:449:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#07.log", line 188, characters 1-1:
+Error: phone-number tests:449:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:444:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#06.log", line 196, characters 1-1:
+Error: phone-number tests:444:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:427:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#06.log", line 182, characters 1-1:
+Error: phone-number tests:427:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:422:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#01.log", line 179, characters 1-1:
+Error: phone-number tests:422:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:405:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#01.log", line 165, characters 1-1:
+Error: phone-number tests:405:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:400:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#03.log", line 162, characters 1-1:
+Error: phone-number tests:400:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:383:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 168, characters 1-1:
+Error: phone-number tests:383:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:378:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#02.log", line 174, characters 1-1:
+Error: phone-number tests:378:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:361:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#04.log", line 168, characters 1-1:
+Error: phone-number tests:361:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:356:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#07.log", line 147, characters 1-1:
+Error: phone-number tests:356:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:339:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 151, characters 1-1:
+Error: phone-number tests:339:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:334:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#02.log", line 151, characters 1-1:
+Error: phone-number tests:334:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:317:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#03.log", line 124, characters 1-1:
+Error: phone-number tests:317:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:312:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#01.log", line 124, characters 1-1:
+Error: phone-number tests:312:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:295:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#04.log", line 136, characters 1-1:
+Error: phone-number tests:295:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:290:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#07.log", line 115, characters 1-1:
+Error: phone-number tests:290:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:273:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#05.log", line 106, characters 1-1:
+Error: phone-number tests:273:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:268:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 128, characters 1-1:
+Error: phone-number tests:268:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:251:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#02.log", line 113, characters 1-1:
+Error: phone-number tests:251:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:246:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#06.log", line 108, characters 1-1:
+Error: phone-number tests:246:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:229:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#02.log", line 99, characters 1-1:
+Error: phone-number tests:229:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:224:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 111, characters 1-1:
+Error: phone-number tests:224:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:207:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 100, characters 1-1:
+Error: phone-number tests:207:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:202:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 92, characters 1-1:
+Error: phone-number tests:202:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:185:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 81, characters 1-1:
+Error: phone-number tests:185:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:180:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 73, characters 1-1:
+Error: phone-number tests:180:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:163:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 62, characters 1-1:
+Error: phone-number tests:163:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:158:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#06.log", line 67, characters 1-1:
+Error: phone-number tests:158:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:141:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#07.log", line 53, characters 1-1:
+Error: phone-number tests:141:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:136:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#04.log", line 71, characters 1-1:
+Error: phone-number tests:136:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:119:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 45, characters 1-1:
+Error: phone-number tests:119:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:114:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 37, characters 1-1:
+Error: phone-number tests:114:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:97:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#08.log", line 26, characters 1-1:
+Error: phone-number tests:97:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:92:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#01.log", line 35, characters 1-1:
+Error: phone-number tests:92:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:75:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#04.log", line 42, characters 1-1:
+Error: phone-number tests:75:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:70:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#04.log", line 34, characters 1-1:
+Error: phone-number tests:70:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:53:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#02.log", line 28, characters 1-1:
+Error: phone-number tests:53:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:48:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#06.log", line 20, characters 1-1:
+Error: phone-number tests:48:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:31:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#02.log", line 14, characters 1-1:
+Error: phone-number tests:31:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:26:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#03.log", line 11, characters 1-1:
+Error: phone-number tests:26:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:9:invalid when more than 11 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#04.log", line 5, characters 1-1:
+Error: phone-number tests:9:invalid when more than 11 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be greater than 11 digits"
+but got: Error "more than 11 digits"
+------------------------------------------------------------------------------
+==============================================================================
+Error: phone-number tests:4:invalid when 9 digits.
+
+File "/tmp/phone-number.aDxWX51QQQ/_build/oUnit-phone-number tests-#05.log", line 2, characters 1-1:
+Error: phone-number tests:4:invalid when 9 digits (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: Error "must not be fewer than 10 digits"
+but got: Error "incorrect number of digits"
+------------------------------------------------------------------------------
+Ran: 484 tests in: 0.14 seconds.
+FAILED: Cases: 484 Tried: 484 Errors: 0 Failures: 44 Skip:  0 Todo: 0 Timeouts: 0.
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/prime-factors/dune-project.tpl
+++ b/templates/prime-factors/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/prime-factors/test.ml.tpl
+++ b/templates/prime-factors/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open OUnit2
 open Prime_factors

--- a/templates/raindrops/dune-project.tpl
+++ b/templates/raindrops/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/raindrops/test.ml.tpl
+++ b/templates/raindrops/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Raindrops
 

--- a/templates/rectangles/dune-project.tpl
+++ b/templates/rectangles/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/rectangles/test.ml.tpl
+++ b/templates/rectangles/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open OUnit2
 open Rectangles
 

--- a/templates/roman-numerals/.broken
+++ b/templates/roman-numerals/.broken
@@ -1,0 +1,10 @@
+----------------------------------------------------------------
+running tests for: roman-numerals
+File "dune", line 5, characters 0-76:
+5 | (alias
+6 |   (name    runtest)
+7 |   (deps    (:x test.exe))
+8 |   (action  (run %{x})))
+Fatal error: exception File "roman_numerals.ml", line 3, characters 2-8: Assertion failed
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/run-length-encoding/dune-project.tpl
+++ b/templates/run-length-encoding/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/run-length-encoding/test.ml.tpl
+++ b/templates/run-length-encoding/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open OUnit2
 open Run_length_encoding

--- a/templates/say/dune-project.tpl
+++ b/templates/say/dune-project.tpl
@@ -1,2 +1,1 @@
 (lang dune 1.1)
-(version {{version}})

--- a/templates/say/test.ml.tpl
+++ b/templates/say/test.ml.tpl
@@ -1,4 +1,3 @@
-(* {{name}} - {{version}} *)
 open Base
 open OUnit2
 open Say

--- a/templates/space-age/.broken
+++ b/templates/space-age/.broken
@@ -1,0 +1,9 @@
+----------------------------------------------------------------
+running tests for: space-age
+File "test.ml", line 28, characters 17-44:
+28 |   ae ~delta:0.05 [("error", "not a planet")] (age_on Sun 680804807);
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type 'a list
+       but an expression was expected of type float
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/triangle/.broken
+++ b/templates/triangle/.broken
@@ -1,0 +1,23 @@
+----------------------------------------------------------------
+running tests for: triangle
+File "dune", line 5, characters 0-76:
+5 | (alias
+6 |   (name    runtest)
+7 |   (deps    (:x test.exe))
+8 |   (action  (run %{x})))
+...........F......
+==============================================================================
+Error: triangle tests:15:first and third sides are equal.
+
+File "/tmp/triangle.QqNmX5eza2/_build/oUnit-triangle tests-#01.log", line 8, characters 1-1:
+Error: triangle tests:15:first and third sides are equal (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: false but got: true
+------------------------------------------------------------------------------
+Ran: 18 tests in: 0.10 seconds.
+FAILED: Cases: 18 Tried: 18 Errors: 0 Failures: 1 Skip:  0 Todo: 0 Timeouts: 0.
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/word-count/.broken
+++ b/templates/word-count/.broken
@@ -1,0 +1,26 @@
+----------------------------------------------------------------
+running tests for: word-count
+File "dune", line 5, characters 0-76:
+5 | (alias
+6 |   (name    runtest)
+7 |   (deps    (:x test.exe))
+8 |   (action  (run %{x})))
+...F...........
+==============================================================================
+Error: word_count tests:9:with apostrophes.
+
+File "/tmp/word-count.bnENv68lwi/_build/oUnit-word_count tests-#02.log", line 5, characters 1-1:
+Error: word_count tests:9:with apostrophes (in the log).
+
+Raised at OUnitAssert.assert_failure in file "src/lib/ounit2/advanced/oUnitAssert.ml", line 45, characters 2-27
+Called from OUnitRunner.run_one_test.(fun) in file "src/lib/ounit2/advanced/oUnitRunner.ml", line 83, characters 13-26
+
+expected: ((cry 1) (don't 2) (first 1) (getting 1) (it 1) (laugh 1) (then 1)
+ (you're 1))
+but got: ((' 1) ('first 1) (cry 1) (don't 2) (getting 1) (it 1) (laugh 1) (then 1)
+ (you're 1))
+------------------------------------------------------------------------------
+Ran: 15 tests in: 0.10 seconds.
+FAILED: Cases: 15 Tried: 15 Errors: 0 Failures: 1 Skip:  0 Todo: 0 Timeouts: 0.
+make[1]: *** [Makefile:4: test] Error 1
+make: *** [Makefile:30: test-assignment] Error 2


### PR DESCRIPTION
This one is dependent on #460 to be reviewed, but I thought I get this out for comments as well.

Updating the problem-specifications is going to lead to broken templates for a great many reasons, making it difficult to update, especially when it has not been updated in over 3 years.

The strategy here is to automatically regenerate the ones that can update cleanly and pass tests, and mark the ones that failed with `.broken`.

These broken templates will be skipped during CI, but each one will create an issue in the repository about the problem with potential pointers on how to fix it allowing more people to easily contribute patches to these templates. They would make great first-issue problems.

Currently there are 10 broken templates, some are easy fixes, others require some thinking. 