### PR TITLE
palindrome-products: Don't make users implement helpers for tests.

### DIFF
--- a/exercises/practice/palindrome-products/.meta/example.ml
+++ b/exercises/practice/palindrome-products/.meta/example.ml
@@ -3,7 +3,7 @@ open Base
 type palindrome_products = {
   value : int option;
   factors : (int * int) list;
-} [@@deriving show, eq]
+}
 
 let is_palindrome n =
   let n = Int.to_string n in String.(rev n = n)
@@ -20,13 +20,13 @@ let empty = Ok {value=None; factors=[]}
 let smallest ~min ~max =
   if min > max
   then Error "min must be <= max"
-  else 
+  else
     let open Sequence.Monad_infix in
     let seq = seq 1 in
-    let products = 
-      seq min max >>= fun x -> 
-      seq x max >>= fun y -> 
-      Sequence.singleton (x * y, (x, y)) 
+    let products =
+      seq min max >>= fun x ->
+      seq x max >>= fun y ->
+      Sequence.singleton (x * y, (x, y))
       |> Sequence.filter ~f:(fun (n, _) -> is_palindrome n) in
     products
       |> Sequence.to_list
@@ -35,16 +35,16 @@ let smallest ~min ~max =
       |> List.hd
       |> Option.value_map ~default:(empty) ~f:(fun x -> Ok (to_palindrome_products x))
 
-let largest ~min ~max = 
+let largest ~min ~max =
   if min > max
   then Error "min must be <= max"
-  else 
+  else
     let open Sequence.Monad_infix in
     let seq = seq (-1) in
-    let products = 
-      seq max min >>= fun x -> 
-      seq x min >>= fun y -> 
-      Sequence.singleton (x * y, (y, x)) 
+    let products =
+      seq max min >>= fun x ->
+      seq x min >>= fun y ->
+      Sequence.singleton (x * y, (y, x))
       |> Sequence.filter ~f:(fun (n, _) -> is_palindrome n) in
     products
       |> Sequence.to_list
@@ -52,5 +52,3 @@ let largest ~min ~max =
       |> List.group ~break:(fun (x, _) (y, _) -> x <> y)
       |> List.hd
       |> Option.value_map ~default:(empty) ~f:(fun x -> Ok (to_palindrome_products x))
-
-  

--- a/exercises/practice/palindrome-products/palindrome_products.ml
+++ b/exercises/practice/palindrome-products/palindrome_products.ml
@@ -8,9 +8,3 @@ let smallest ~min ~max =
 
 let largest ~min ~max =
   failwith "'largest' is missing"
-
-let show_palindrome_products _ =
-  failwith "'show_palindrome_products' is missing"
-
-let equal_palindrome_products _ _ =
-  failwith "'equal_palindrome_products' is missing"

--- a/exercises/practice/palindrome-products/palindrome_products.mli
+++ b/exercises/practice/palindrome-products/palindrome_products.mli
@@ -10,13 +10,3 @@ val smallest : min : int -> max : int -> (palindrome_products, string) result
 (* Returns the largest palindrome with factors in the given range, or an appropriate
    error result if the range is ill specified, or there are no palindromes in the range. *)
 val largest : min : int -> max : int -> (palindrome_products, string) result
-
-(* These are helper functions for tests. They can be written by hand, or using ppx_deriving
-   https://github.com/ocaml-ppx/ppx_deriving/blob/master/README.md.
-*)
-
-(* Returns a string representation of a palindrome_products. *)
-val show_palindrome_products : palindrome_products -> string
-
-(* Returns true if two palindrome_products are equal. *)
-val equal_palindrome_products : palindrome_products -> palindrome_products -> bool

--- a/exercises/practice/palindrome-products/test.ml
+++ b/exercises/practice/palindrome-products/test.ml
@@ -1,6 +1,15 @@
 open OUnit2
 open Palindrome_products
 
+module For_tests = struct
+  type palindrome_products = Palindrome_products.palindrome_products = {
+    value : int option;
+    factors : (int * int) list;
+  } [@@deriving eq, show]
+end
+
+open For_tests
+
 let show_result printer = function
   | Error e -> "Error " ^ e
   | Ok a -> "Ok " ^ printer a

--- a/templates/palindrome-products/test.ml.tpl
+++ b/templates/palindrome-products/test.ml.tpl
@@ -1,6 +1,15 @@
 open OUnit2
 open Palindrome_products
 
+module For_tests = struct
+  type palindrome_products = Palindrome_products.palindrome_products = {
+  value : int option;
+  factors : (int * int) list;
+} [@@deriving eq, show]
+end
+
+open For_tests
+
 let show_result printer = function
 | Error e -> "Error " ^ e
 | Ok a -> "Ok " ^ printer a
@@ -10,7 +19,7 @@ let eq_results eq x y = match (x, y) with
 | (Ok x, Ok y) -> eq x y
 | _ -> false
 
-let ae exp got _test_ctxt = 
+let ae exp got _test_ctxt =
   assert_equal ~printer:(show_result show_palindrome_products) ~cmp:(eq_results equal_palindrome_products) exp got
 
 let tests = [


### PR DESCRIPTION
The exercise is about creating about finding the largest and smallest palindromes, not about creating tedious equals and print functions. The .mli even states these as helper functions for running tests. Instead we should own those test functions ourselves.

This is somewhat related to #496 as I was going through to remove ppx_deriving I realized how painful creating these helper functions is and how unrelated it is to the actual problem. 