### PR TITLE
Update example file path in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,7 +29,7 @@
       "test.ml"
     ],
     "example": [
-      "example.ml"
+      ".meta/example.ml"
     ],
     "exemplar": [
       ".meta/exemplar.ml"


### PR DESCRIPTION
Configlet lint expects  `example` to contain a path relative to the exercise folder. At the moment, the example.ml path needs to be tweaked manually in the exercise's config file.