### PR TITLE
Space age  - fix broken tests

### DIFF
--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -12,21 +12,14 @@
     "sbl",
     "sshine",
     "stevejb71",
+    "therealowenrees",
     "tmcgilchrist"
   ],
   "files": {
-    "solution": [
-      "space_age.ml"
-    ],
-    "test": [
-      "test.ml"
-    ],
-    "example": [
-      ".meta/example.ml"
-    ],
-    "editor": [
-      "space_age.mli"
-    ]
+    "solution": ["space_age.ml"],
+    "test": ["test.ml"],
+    "example": [".meta/example.ml"],
+    "editor": ["space_age.mli"]
   },
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -16,10 +16,18 @@
     "tmcgilchrist"
   ],
   "files": {
-    "solution": ["space_age.ml"],
-    "test": ["test.ml"],
-    "example": [".meta/example.ml"],
-    "editor": ["space_age.mli"]
+    "solution": [
+      "space_age.ml"
+    ],
+    "test": [
+      "test.ml"
+    ],
+    "example": [
+      ".meta/example.ml"
+    ],
+    "editor": [
+      "space_age.mli"
+    ]
   },
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",

--- a/exercises/practice/space-age/.meta/example.ml
+++ b/exercises/practice/space-age/.meta/example.ml
@@ -1,22 +1,19 @@
 open Base
 
-type planet = Mercury | Venus | Earth | Mars
-            | Jupiter | Saturn | Neptune | Uranus
-
 let earth_years seconds = seconds /. 31557600.0
-
 let rel_years = function
-    | Mercury -> 0.2408467
-    | Venus   -> 0.61519726
-    | Earth   -> 1.
-    | Mars    -> 1.8808158
-    | Jupiter -> 11.862615
-    | Saturn  -> 29.447498
-    | Uranus  -> 84.016846
-    | Neptune -> 164.79132
+    | "Mercury" -> 0.2408467
+    | "Venus"   -> 0.61519726
+    | "Mars"    -> 1.8808158
+    | "Earth"   -> 1.
+    | "Jupiter" -> 11.862615
+    | "Saturn"  -> 29.447498
+    | "Uranus"  -> 84.016846
+    | "Neptune" -> 164.79132
+    | _         -> 1.
 
 let age_on planet seconds =
     let seconds' = Float.of_int seconds in
     match planet with
-    | Earth -> earth_years seconds' 
-    | _     -> earth_years seconds' /. rel_years planet
+    | "Mercury" | "Venus" | "Earth" | "Mars" | "Jupiter" | "Saturn" | "Uranus" | "Neptune" -> Ok (earth_years seconds' /. rel_years planet)
+    | _ -> Error "not a planet"

--- a/exercises/practice/space-age/space_age.ml
+++ b/exercises/practice/space-age/space_age.ml
@@ -1,5 +1,2 @@
-type planet = Mercury | Venus | Earth | Mars
-            | Jupiter | Saturn | Neptune | Uranus
-
 let age_on _ _ =
     failwith "'age_on' is missing"

--- a/exercises/practice/space-age/space_age.mli
+++ b/exercises/practice/space-age/space_age.mli
@@ -1,7 +1,4 @@
 (** Space-age exercise *)
 
-type planet = Mercury | Venus | Earth | Mars
-            | Jupiter | Saturn | Neptune | Uranus
-
 (** Convert seconds to years on the specified planet *)
-val age_on : planet -> int -> float
+val age_on : string -> int -> (float, string) Result.t 

--- a/exercises/practice/space-age/test.ml
+++ b/exercises/practice/space-age/test.ml
@@ -3,30 +3,38 @@ open Base
 open OUnit2
 open Space_age
 
-let ae ~delta:delta exp got _ctxt =
-  let msg = Printf.sprintf "Expected %f got %f, difference is greater than %f"
-      exp got delta in
-  assert_bool msg (cmp_float ~epsilon:delta exp got)
+let ae ~delta exp_result got_result _test_ctxt =
+  match (exp_result, got_result) with
+  | Ok exp, Ok got ->
+    let diff = Float.abs (exp -. got) in
+    let msg = Printf.sprintf "Expected %f, got %f (diff %f > delta %f)" exp got diff delta in
+    assert_bool msg (Float.(diff <= delta))
+  | Error exp_msg, Error got_msg ->
+    assert_equal exp_msg got_msg ~printer:Fn.id
+  | Ok _, Error m ->
+    assert_failure (Printf.sprintf "Expected Ok, but got Error: %s" m)
+  | Error m, Ok _ ->
+    assert_failure (Printf.sprintf "Expected Error: %s, but got Ok" m)
 
 let tests = [
   "age on Earth" >::
-  ae ~delta:0.05 31.69 (age_on Earth 1000000000);
+  ae ~delta:0.05 (Ok 31.69) (age_on "Earth" 1000000000);
   "age on Mercury" >::
-  ae ~delta:0.05 280.88 (age_on Mercury 2134835688);
+  ae ~delta:0.05 (Ok 280.88) (age_on "Mercury" 2134835688);
   "age on Venus" >::
-  ae ~delta:0.05 9.78 (age_on Venus 189839836);
+  ae ~delta:0.05 (Ok 9.78) (age_on "Venus" 189839836);
   "age on Mars" >::
-  ae ~delta:0.05 35.88 (age_on Mars 2129871239);
+  ae ~delta:0.05 (Ok 35.88) (age_on "Mars" 2129871239);
   "age on Jupiter" >::
-  ae ~delta:0.05 2.41 (age_on Jupiter 901876382);
+  ae ~delta:0.05 (Ok 2.41) (age_on "Jupiter" 901876382);
   "age on Saturn" >::
-  ae ~delta:0.05 2.15 (age_on Saturn 2000000000);
+  ae ~delta:0.05 (Ok 2.15) (age_on "Saturn" 2000000000);
   "age on Uranus" >::
-  ae ~delta:0.05 0.46 (age_on Uranus 1210123456);
+  ae ~delta:0.05 (Ok 0.46) (age_on "Uranus" 1210123456);
   "age on Neptune" >::
-  ae ~delta:0.05 0.35 (age_on Neptune 1821023456);
+  ae ~delta:0.05 (Ok 0.35) (age_on "Neptune" 1821023456);
   "invalid planet causes error" >::
-  ae ~delta:0.05 [("error", "not a planet")] (age_on Sun 680804807);
+  ae ~delta:0.05 (Error "not a planet") (age_on "Sun" 680804807);
 ]
 
 let () =

--- a/exercises/practice/space-age/test.ml
+++ b/exercises/practice/space-age/test.ml
@@ -1,4 +1,4 @@
-(* space-age - 1.2.0 *)
+(* space-age - 1.0 *)
 open Base
 open OUnit2
 open Space_age
@@ -25,6 +25,8 @@ let tests = [
   ae ~delta:0.05 0.46 (age_on Uranus 1210123456);
   "age on Neptune" >::
   ae ~delta:0.05 0.35 (age_on Neptune 1821023456);
+  "invalid planet causes error" >::
+  ae ~delta:0.05 [("error", "not a planet")] (age_on Sun 680804807);
 ]
 
 let () =

--- a/templates/space-age/.broken
+++ b/templates/space-age/.broken
@@ -1,9 +1,0 @@
-----------------------------------------------------------------
-running tests for: space-age
-File "test.ml", line 28, characters 17-44:
-28 |   ae ~delta:0.05 [("error", "not a planet")] (age_on Sun 680804807);
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type 'a list
-       but an expression was expected of type float
-make[1]: *** [Makefile:4: test] Error 1
-make: *** [Makefile:30: test-assignment] Error 2

--- a/templates/space-age/test.ml.tpl
+++ b/templates/space-age/test.ml.tpl
@@ -3,15 +3,23 @@ open Base
 open OUnit2
 open Space_age
 
-let ae ~delta:delta exp got _ctxt =
-  let msg = Printf.sprintf "Expected %f got %f, difference is greater than %f"
-                    exp got delta in
-  assert_bool msg (cmp_float ~epsilon:delta exp got)
+let ae ~delta exp_result got_result _test_ctxt =
+  match (exp_result, got_result) with
+  | Ok exp, Ok got ->
+      let diff = Float.abs (exp -. got) in
+      let msg = Printf.sprintf "Expected %f, got %f (diff %f > delta %f)" exp got diff delta in
+      assert_bool msg (Float.(diff <= delta))
+  | Error exp_msg, Error got_msg ->
+      assert_equal exp_msg got_msg ~printer:Fn.id
+  | Ok _, Error m -> 
+      assert_failure (Printf.sprintf "Expected Ok, but got Error: %s" m)
+  | Error m, Ok _ -> 
+      assert_failure (Printf.sprintf "Expected Error: %s, but got Ok" m)
 
 let tests = [
 {{#cases}}
    "{{description}}" >::
-      ae ~delta:0.05 {{#input}}{{expected}} (age_on {{planet}} {{seconds}}){{/input}};
+      ae ~delta:0.05 ({{#input}}{{expected}}) (age_on "{{planet}}" {{seconds}}){{/input}};
    {{/cases}}
 ]
 

--- a/test-generator/lib_generator/special_cases.ml
+++ b/test-generator/lib_generator/special_cases.ml
@@ -171,10 +171,20 @@ let edit_minesweeper (ps: (string * json) list): (string * string) list =
     | (k, v) -> (k, json_to_string v) in
   List.map ps ~f:edit
 
-let edit_space_age (ps: (string * json) list): (string * string) list =
-  let edit = function
-    | ("planet", v) -> ("planet", json_to_string v |> strip_quotes)
-    | (k, v) -> (k, json_to_string v) in
+  let edit_space_age (ps: (string * json) list): (string * string) list =
+    let edit = function
+      | ("planet", v) -> 
+          ("planet", json_to_string v |> strip_quotes)
+      | ("expected", v) ->
+          let wrapped = match v with
+            | `Float f -> Printf.sprintf "Ok %.2f" f
+            | `Int i   -> Printf.sprintf "Ok %.2f" (Float.of_int i)
+            | `Assoc [("error", `String msg)] -> Printf.sprintf "Error %S" msg
+            | _ -> json_to_string v
+          in
+          ("expected", wrapped)
+      | (k, v) -> (k, json_to_string v) 
+  in
   List.map ps ~f:edit
 
 let null_to_option = function `Null -> "None" | x -> Printf.sprintf "(Some %s)" (json_to_string x)


### PR DESCRIPTION
In reference to https://github.com/exercism/ocaml/issues/474

- Options replaced with an un-OCaml like string match
- Return type as `Result.t`

- This will affect all current solutions to this exercise. 
- I am not sure if this changes the difficulty of the exercise, since it relies on Base now