### PR TITLE
update `triangle` toml - no new tests

### DIFF
--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -23,6 +23,7 @@ description = "equilateral triangle -> all zero sides is not a triangle"
 
 [3022f537-b8e5-4cc1-8f12-fd775827a00c]
 description = "equilateral triangle -> sides may be floats"
+include = false
 
 [cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
 description = "isosceles triangle -> last two sides are equal"
@@ -50,6 +51,7 @@ description = "isosceles triangle -> third triangle inequality violation"
 
 [adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
 description = "isosceles triangle -> sides may be floats"
+include = false
 
 [e8b5f09c-ec2e-47c1-abec-f35095733afb]
 description = "scalene triangle -> no sides are equal"
@@ -58,10 +60,17 @@ description = "scalene triangle -> no sides are equal"
 description = "scalene triangle -> all sides are equal"
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
-description = "scalene triangle -> two sides are equal"
+description = "scalene triangle -> first and second sides are equal"
+
+[3da23a91-a166-419a-9abf-baf4868fd985]
+description = "scalene triangle -> first and third sides are equal"
+
+[b6a75d98-1fef-4c42-8e9a-9db854ba0a4d]
+description = "scalene triangle -> second and third sides are equal"
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
 description = "scalene triangle -> may not violate triangle inequality"
 
 [26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
 description = "scalene triangle -> sides may be floats"
+include = false


### PR DESCRIPTION
Mark as tiny. No tests have been added, but tests.toml is now updated to reflect that the float tests are now skipped and that the other scalene tests were already added previously.