### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/atbash-cipher/.docs/instructions.append.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.append.md
@@ -1,7 +1,10 @@
-# Deprecation of String.lowercase
-Depending on the version of OCaml you installed the use of `String.lowercase` is
-frowned upon. Since version 4.03.0 `String.lowercase` is deprecated in favor of
-`String.lowercase_ascii`. So instead of writing 
+# Instructions append
+
+## Deprecation of `String.lowercase`
+
+Depending on the version of OCaml you installed the use of `String.lowercase` is frowned upon.
+Since version 4.03.0 `String.lowercase` is deprecated in favor of `String.lowercase_ascii`.
+So instead of writing 
 
 ```ocaml
 String.lowercase "Hello, World!"
@@ -13,5 +16,6 @@ use
 String.lowercase_ascii "Hello, World!"
 ```
 
-See [String documentation](http://caml.inria.fr/pub/docs/manual-ocaml/libref/String.html) 
-for more useful functions.
+See [String documentation][string] for more useful functions.
+
+[string]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/String.html


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.